### PR TITLE
feat: print undeclared variables as text nodes

### DIFF
--- a/src/mdx/plugins/remark-undeclared-variables.ts
+++ b/src/mdx/plugins/remark-undeclared-variables.ts
@@ -1,0 +1,59 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import visit from 'unist-util-visit';
+import { Node } from 'unist';
+const defaultOptions = {
+  callback: () => {
+    return;
+  },
+};
+
+/**
+ * Provides a list of declared variables
+ * @returns
+ */
+
+interface DeclaredNode extends Node {
+  value: string;
+}
+interface UnDeclaredNode extends Node {
+  value: string;
+  data: any;
+}
+
+export default function rehastUndeclaredVariables(options = defaultOptions): (ast: Node) => void {
+  const keywords = ['var', 'let', 'const', 'function'];
+  const withExport = keywords.map(k => new RegExp(`(export)[ \t]+${k}[ \t]`));
+
+  const declared = [];
+
+  function visitorForDeclared(node: DeclaredNode) {
+    // Get the kind of export. This is actually stored in the Node, but the following was quicker for typescript:
+    const exportKeyword = withExport.filter(re => re.test(node.value))[0];
+
+    if (!!exportKeyword) {
+      declared.push(
+        node.value
+          .replace(exportKeyword, '')
+          .replace(/^[a-z0-9-_A-Z]*[ \t][a-z0-9-_A-Z]*[ \t]/, '')
+          .split(' ')[0],
+      );
+    }
+  }
+
+  const undeclared = [];
+
+  function visitorForUndeclared(node: UnDeclaredNode) {
+    if (!declared.includes(node.value)) {
+      undeclared.push(node.value);
+      node.type = 'text';
+      node.data = undefined;
+      node.value = `\{${node.value}\}`;
+    }
+  }
+
+  return async (ast: Node): Promise<void> => {
+    visit(ast, 'mdxjsEsm', visitorForDeclared);
+    visit(ast, 'mdxFlowExpression', visitorForUndeclared);
+    options.callback(undeclared);
+  };
+}

--- a/src/mdx/plugins/remark-undeclared-variables.ts
+++ b/src/mdx/plugins/remark-undeclared-variables.ts
@@ -1,14 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import visit from 'unist-util-visit';
 import { Node } from 'unist';
-const defaultOptions = {
-  callback: () => {
-    return;
-  },
-};
 
 /**
- * Provides a list of declared variables
+ * Converts undeclared variables into plain text nodes
  * @returns
  */
 
@@ -20,7 +15,7 @@ interface UnDeclaredNode extends Node {
   data: any;
 }
 
-export default function rehastUndeclaredVariables(options = defaultOptions): (ast: Node) => void {
+export default function rehastUndeclaredVariables(): (ast: Node) => void {
   const keywords = ['var', 'let', 'const', 'function'];
   const withExport = keywords.map(k => new RegExp(`(export)[ \t]+${k}[ \t]`));
 
@@ -54,6 +49,5 @@ export default function rehastUndeclaredVariables(options = defaultOptions): (as
   return async (ast: Node): Promise<void> => {
     visit(ast, 'mdxjsEsm', visitorForDeclared);
     visit(ast, 'mdxFlowExpression', visitorForUndeclared);
-    options.callback(undeclared);
   };
 }

--- a/src/utils/mdx-serialize.ts
+++ b/src/utils/mdx-serialize.ts
@@ -9,7 +9,7 @@ import { HeadingNode, PageContent } from './content';
 import { headerDepthToHeaderList } from './index';
 import rehypeCodeBlocks from '../mdx/plugins/rehype-code-blocks';
 import rehypeHeadings from '../mdx/plugins/rehype-headings';
-
+import rehastUndeclaredVariables from '../mdx/plugins/remark-undeclared-variables';
 interface SerializationResponse {
   source: string;
   headings: HeadingNode[];
@@ -32,6 +32,8 @@ export async function mdxSerialize(content: PageContent): Promise<SerializationR
   };
 
   const remarkPlugins = [
+    // Convert undeclared variables to strings
+    rehastUndeclaredVariables,
     // Support GitHub flavoured markdown
     remarkGfm,
     // Ensure any `img` tags are not wrapped in `p` tags


### PR DESCRIPTION
- add remark plugin to convert undeclared variables to text
- added to bundler options

This will convert any node of the type `mdxFlowExpression` that is not exported using a node of type `mdxjsEsm` to a text node of the same value. It will not affect undefined components as they are given by `mdxJsxFlowElement` type.