### PR TITLE
feat: support docs.yaml and docs.toml configs

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -24,6 +24,7 @@
     "hast-util-parse-selector": "^3.1.0",
     "http-status": "^1.5.0",
     "is-badge": "^2.1.0",
+    "js-yaml": "^4.1.0",
     "lodash.get": "^4.4.2",
     "mdx-bundler": "^8.0.0",
     "morgan": "^1.10.0",
@@ -38,6 +39,7 @@
     "remark-parse": "^10.0.1",
     "shiki": "^0.9.15",
     "tiny-invariant": "^1.2.0",
+    "toml": "^3.0.0",
     "typescript": "4.4.4",
     "unist-util-visit": "^4.1.0"
   },

--- a/api/src/utils/bundle.ts
+++ b/api/src/utils/bundle.ts
@@ -192,7 +192,6 @@ export class Bundle {
       } else if (configYaml) {
         inputConfig = yaml.load(configYaml) as InputConfig;
       } else if (configToml) {
-        // inputConfig = toml.parse(configToml) as InputConfig;
         inputConfig = Object.assign({}, toml.parse(configToml)) as InputConfig;
         console.log(JSON.parse(JSON.stringify(inputConfig)));
       }

--- a/api/src/utils/bundle.ts
+++ b/api/src/utils/bundle.ts
@@ -194,7 +194,7 @@ export class Bundle {
       } else if (configToml) {
         // inputConfig = toml.parse(configToml) as InputConfig;
         inputConfig = Object.assign({}, toml.parse(configToml)) as InputConfig;
-        console.log(JSON.parse(JSON.stringify(inputConfig)))
+        console.log(JSON.parse(JSON.stringify(inputConfig)));
       }
     } catch (e) {
       throw new BundleError(500, 'Error parsing config');

--- a/api/src/utils/bundle.ts
+++ b/api/src/utils/bundle.ts
@@ -1,11 +1,12 @@
-import fetch from 'node-fetch';
 import { bundle } from './bundler.js';
 import { getPlugins } from './getPlugins.js';
-import { Contents, getGitHubContents } from './github.js';
+import { Contents, getConfigs, getGitHubContents } from './github.js';
 import { HeadingNode } from './plugins/rehype-headings.js';
 import { formatSourceAndRef } from './ref.js';
 import { getRepositorySymLinks } from './symlinks.js';
 import { hasLocales, InputConfig, OutputConfig, defaultConfig } from '@docs.page/server';
+import yaml from 'js-yaml';
+import toml from 'toml';
 
 type Frontmatter = Record<string, string>;
 
@@ -109,18 +110,16 @@ export class Bundle {
   }
 
   async getConfig() {
-    const { owner, repository, ref } = this.source;
-    const extension = '.json';
+    const { repositoryFound, config } = await getConfigs({
+      ...this.source,
+      path: this.path,
+    });
 
-    const endpoint = `https://raw.githubusercontent.com/${owner}/${repository}/${ref}/docs${extension}`;
-    let configString: string;
-    try {
-      configString = await (await fetch(endpoint)).text();
-      // TODO: validate config
-    } catch (e) {
+    if (!repositoryFound || !config) {
       throw new BundleError(404, 'Unable to fetch config file.');
     }
-    this.formatConfigLocales(configString);
+    this.formatConfigLocales(config);
+
     return this.config;
   }
 
@@ -177,12 +176,26 @@ export class Bundle {
     }
   }
 
-  formatConfigLocales(configString: string) {
-    let inputConfig: InputConfig;
+  formatConfigLocales(config?: { configJson?: string; configYaml?: string; configToml?: string }) {
+    if (!config) {
+      this.config = defaultConfig;
+      return;
+    }
+    const { configJson, configYaml, configToml } = config;
 
+    let inputConfig: InputConfig = defaultConfig;
     // TODO: validation of config?
+
     try {
-      inputConfig = JSON.parse(configString) as InputConfig;
+      if (configJson) {
+        inputConfig = JSON.parse(configJson) as InputConfig;
+      } else if (configYaml) {
+        inputConfig = yaml.load(configYaml) as InputConfig;
+      } else if (configToml) {
+        // inputConfig = toml.parse(configToml) as InputConfig;
+        inputConfig = Object.assign({}, toml.parse(configToml)) as InputConfig;
+        console.log(JSON.parse(JSON.stringify(inputConfig)))
+      }
     } catch (e) {
       throw new BundleError(500, 'Error parsing config');
     }

--- a/api/src/utils/bundle.ts
+++ b/api/src/utils/bundle.ts
@@ -193,7 +193,6 @@ export class Bundle {
         inputConfig = yaml.load(configYaml) as InputConfig;
       } else if (configToml) {
         inputConfig = Object.assign({}, toml.parse(configToml)) as InputConfig;
-        console.log(JSON.parse(JSON.stringify(inputConfig)));
       }
     } catch (e) {
       throw new BundleError(500, 'Error parsing config');


### PR DESCRIPTION
- This PR Allows different config file formats.
- makes docs.page more attractive to users in other languages

Note: examples will probably need adding to use.docs.page.