### PR TITLE
chore: add domain and repository mappings for LunaSea

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -22,5 +22,9 @@
 	[
 		"gorouter.dev",
 		"csells/go_router"
+	],
+	[
+		"docs.lunasea.app",
+		"JagandeepBrar/LunaSea"
 	]
 ]

--- a/repositories.json
+++ b/repositories.json
@@ -1,5 +1,6 @@
 [
   "invertase/docs.page",
   "invertase/melos",
-  "csells/go_router"
+  "csells/go_router",
+  "JagandeepBrar/LunaSea"
 ]


### PR DESCRIPTION
This adds a repository/domain mapping for https://github.com/JagandeepBrar/LunaSea.

The DNS record is currently pointing to the old documentation site, but will be switched once this PR is merged to prevent minimal downtime (if it needs to be switched beforehand, please let me know).
