### PR TITLE
fix: extract tab content in remix prod

### DIFF
--- a/website/app/components/mdx/Tabs.tsx
+++ b/website/app/components/mdx/Tabs.tsx
@@ -123,7 +123,7 @@ function extractTabItems(children: React.ReactNode): TabItemElement[] {
       // @ts-ignore access private name which works on production
       const name = child.type.name;
 
-      if (name === 'TabItem') {
+      if (name) {
         items = [...items, child];
       }
     }
@@ -212,5 +212,5 @@ type TabItemProps = {
 };
 
 export const TabItem: React.FC<TabItemProps> = (props: TabItemProps) => {
-  return <>{props.children}</>;
+  return <div>{props.children}</div>;
 };


### PR DESCRIPTION
- with remix the output seems to be minified, and so `name === TabItem` is no longer valid. Just checking the name is truthy seems to work, but i'm not sure it works for all cases here

 - Fixes #162 