### PR TITLE
fix: prevent infinite loop in react devtools

### DIFF
--- a/website/app/components/ScrollSpy.tsx
+++ b/website/app/components/ScrollSpy.tsx
@@ -5,7 +5,7 @@ import { useDocumentationContext } from '~/context';
 export function ScrollSpy(): JSX.Element {
   const { headings } = useDocumentationContext();
   const [active, setActive] = useState<string>('');
-
+  console.log(headings);
   useEffect(() => {
     if (!headings) {
       return;
@@ -30,7 +30,7 @@ export function ScrollSpy(): JSX.Element {
     headings.forEach(({ id }) => {
       let el;
       try {
-        el = document.querySelector(`#${id}`);
+        el = document.getElementById(id);
       } catch (e) {
         console.error(`heading ${id} cannot be found`);
       }

--- a/website/app/components/ScrollSpy.tsx
+++ b/website/app/components/ScrollSpy.tsx
@@ -5,7 +5,6 @@ import { useDocumentationContext } from '~/context';
 export function ScrollSpy(): JSX.Element {
   const { headings } = useDocumentationContext();
   const [active, setActive] = useState<string>('');
-  console.log(headings);
   useEffect(() => {
     if (!headings) {
       return;


### PR DESCRIPTION
- replace querySelector with getElementById, as the former does not support id selectors starting with a number