### PR TITLE
fix: update ref handling on api to match github change

### DIFF
--- a/api/src/controllers/config.ts
+++ b/api/src/controllers/config.ts
@@ -40,7 +40,7 @@ export const getConfig = async (
 const extractQueryData = (req: Request) => {
   const owner = req?.query?.owner as string;
   const repository = (req?.query?.repository as string) || null;
-  const ref = (req?.query.ref as string) || 'HEAD';
+  const ref = req?.query.ref as string;
   const path = (req?.query.path as string) || 'index';
   return {
     owner,

--- a/api/src/controllers/github.ts
+++ b/api/src/controllers/github.ts
@@ -44,7 +44,7 @@ export const bundleGitHub = async (
 const extractQueryData = (req: Request) => {
   const owner = req?.query?.owner as string;
   const repository = (req?.query?.repository as string) || null;
-  const ref = (req?.query.ref as string) || 'HEAD';
+  const ref = req?.query.ref as string;
   const path = (req?.query.path as string) || 'index';
   const headerDepth = req?.query?.headerDepth ? parseInt(req?.query?.headerDepth as string) : 3;
   return {

--- a/api/src/utils/bundle.ts
+++ b/api/src/utils/bundle.ts
@@ -20,7 +20,7 @@ type Source = {
   type: 'PR' | 'commit' | 'branch';
   owner: string;
   repository: string;
-  ref: string;
+  ref?: string;
 };
 
 type BundleConstructorParams = {
@@ -44,7 +44,7 @@ export class Bundle {
   repositoryFound: boolean;
   source: Source;
   sourceChecked: boolean;
-  ref: string;
+  ref?: string;
   headerDepth: number;
   built: boolean;
   contentFetched: boolean;
@@ -71,9 +71,9 @@ export class Bundle {
       type: 'branch',
       owner,
       repository,
-      ref: ref || 'HEAD',
+      ref: ref,
     };
-    this.ref = ref || 'HEAD';
+    this.ref = ref;
     this.sourceChecked = false;
     this.built = false;
     this.contentFetched = false;
@@ -107,6 +107,12 @@ export class Bundle {
       throw new BundleError(404, "Couldn't find github contents", 'REPO_NOT_FOUND');
     }
     this.baseBranch = githubContents.baseBranch;
+
+    if (!this.ref) {
+      this.ref = this.baseBranch;
+      this.source.ref = this.baseBranch;
+    }
+
     this.repositoryFound = githubContents.repositoryFound;
 
     this.formatConfigLocales(githubContents.config);
@@ -164,7 +170,7 @@ export class Bundle {
       this.source.owner,
       this.source.repository,
       'docs',
-      this.source.ref,
+      this.source.ref!,
     );
 
     const matches = symLinks.filter(s => s.formattedPath === this.path);

--- a/api/src/utils/github.ts
+++ b/api/src/utils/github.ts
@@ -30,7 +30,7 @@ export function getGithubGQLClient(): typeof graphql {
 export type MetaData = {
   owner: string;
   repository: string;
-  ref: string;
+  ref?: string;
   path: string;
 };
 
@@ -75,6 +75,9 @@ export async function getGitHubContents(metadata: MetaData, noDir?: boolean): Pr
   const base = noDir ? '' : 'docs/';
   const absolutePath = `${base}${metadata.path}`;
   const indexPath = `${base}${metadata.path}/index`;
+
+  const ref = metadata.ref || 'HEAD';
+
   const [error, response] = await A2A<PageContentsQuery>(
     getGithubGQLClient()({
       query: `
@@ -114,11 +117,11 @@ export async function getGitHubContents(metadata: MetaData, noDir?: boolean): Pr
     `,
       owner: metadata.owner,
       repository: metadata.repository,
-      configJson: `${metadata.ref}:docs.json`,
-      configYaml: `${metadata.ref}:docs.yaml`,
-      configToml: `${metadata.ref}:docs.toml`,
-      mdx: `${metadata.ref}:${absolutePath}.mdx`,
-      mdxIndex: `${metadata.ref}:${indexPath}.mdx`,
+      configJson: `${ref}:docs.json`,
+      configYaml: `${ref}:docs.yaml`,
+      configToml: `${ref}:docs.toml`,
+      mdx: `${ref}:${absolutePath}.mdx`,
+      mdxIndex: `${ref}:${indexPath}.mdx`,
     }),
   );
 
@@ -230,6 +233,8 @@ type ConfigResponse = {
 };
 
 export async function getConfigs(metadata: MetaData): Promise<Configs> {
+  const ref = metadata.ref || 'HEAD';
+
   const [error, response] = await A2A<ConfigResponse>(
     getGithubGQLClient()({
       query: `
@@ -255,9 +260,9 @@ export async function getConfigs(metadata: MetaData): Promise<Configs> {
     `,
       owner: metadata.owner,
       repository: metadata.repository,
-      json: `${metadata.ref}:docs.json`,
-      yaml: `${metadata.ref}:docs.yaml`,
-      toml: `${metadata.ref}:docs.toml`,
+      json: `${ref}:docs.json`,
+      yaml: `${ref}:docs.yaml`,
+      toml: `${ref}:docs.toml`,
     }),
   );
 

--- a/api/src/utils/ref.ts
+++ b/api/src/utils/ref.ts
@@ -1,11 +1,11 @@
 import { getPullRequestMetadata } from './github.js';
 
-export async function formatSourceAndRef(owner: string, repository: string, ref: string) {
+export async function formatSourceAndRef(owner: string, repository: string, ref?: string) {
   let source: {
     type: 'PR' | 'commit' | 'branch';
     owner: string;
     repository: string;
-    ref: string;
+    ref?: string;
   } = {
     type: 'branch',
     owner: owner || '',
@@ -13,7 +13,7 @@ export async function formatSourceAndRef(owner: string, repository: string, ref:
     ref: ref,
   };
 
-  if (/^[0-9]*$/.test(ref)) {
+  if (ref && /^[0-9]*$/.test(ref)) {
     // Fetch the PR metadata
     const metadata = await getPullRequestMetadata(owner, repository, ref);
     // If the PR was found, update the pointer and source
@@ -24,7 +24,7 @@ export async function formatSourceAndRef(owner: string, repository: string, ref:
         ...metadata,
       };
     }
-  } else if (/^[a-fA-F0-9]{40}$/.test(ref)) {
+  } else if (ref && /^[a-fA-F0-9]{40}$/.test(ref)) {
     source = {
       type: 'commit',
       owner,

--- a/website/app/context.tsx
+++ b/website/app/context.tsx
@@ -74,6 +74,8 @@ export function useImagePath(src: string) {
 export function useRawBlob(path: string): string {
   const { source, baseBranch } = React.useContext(DocumentationContext);
   const { owner, repository: repo, ref } = source;
+  console.log(ref, baseBranch, source);
+
   if (source.type === 'branch') {
     return `https://raw.githubusercontent.com/${owner}/${repo}/${
       ref ?? baseBranch

--- a/website/app/context.tsx
+++ b/website/app/context.tsx
@@ -74,7 +74,6 @@ export function useImagePath(src: string) {
 export function useRawBlob(path: string): string {
   const { source, baseBranch } = React.useContext(DocumentationContext);
   const { owner, repository: repo, ref } = source;
-  console.log(ref, baseBranch, source);
 
   if (source.type === 'branch') {
     return `https://raw.githubusercontent.com/${owner}/${repo}/${


### PR DESCRIPTION
fixes https://github.com/invertase/docs.page/issues/181

Github seems to have removed support for 'HEAD' in raw image links. This broke some default behaviour, which this PR fixes.