### PR TITLE
docs: fixed formatting of Image markdown

### DIFF
--- a/docs/components.mdx
+++ b/docs/components.mdx
@@ -77,7 +77,7 @@ The component also allows you to synchronize selected tab choices by providing a
 
 ## `<Image />`
 
-Basic Markdown syntax for images works out of the box (e.g. `![alt tag](src)), however using the `Image`
+Basic Markdown syntax for images works out of the box (e.g. `![alt tag](src)`), however using the `Image`
 component directly allows for a bit more control on some of the properties.
 
 ### Zooming


### PR DESCRIPTION
The formatting of the markdown for the out of the box image was improperly formatted. This PR fixes this.