### PR TITLE
fix: link to advanced page is broken

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -74,7 +74,7 @@ project config file is not found.
 | --------- | --------- | ------- |
 | `noindex` | `boolean` | `false` |
 
-To learn more about indexing, view the [Advanced documentation](advanced).
+To learn more about indexing, view the [Advanced documentation](/advanced).
 
 ### `theme`
 


### PR DESCRIPTION
The link to the advanced page points to `advanced` instead of `/advanced`. Therefore, the use is directed to [https://use.docs.pageadvanced/](https://use.docs.pageadvanced/) instead of [https://use.docs.page/advanced](https://use.docs.page/advanced).