### PR TITLE
fix: ensure ref usage is uri encoded

### DIFF
--- a/website/app/components/DocsLink.tsx
+++ b/website/app/components/DocsLink.tsx
@@ -30,7 +30,7 @@ export function DocsLink({ ...props }: NavLinkProps): JSX.Element {
   let to = `/${owner}/${repo}`;
 
   if (ref && ref !== 'HEAD') {
-    to += `~${ref}`;
+    to += `~${encodeURIComponent(ref)}`;
   }
 
   if (previewMode.enabled) {
@@ -52,7 +52,7 @@ export function DocsLink({ ...props }: NavLinkProps): JSX.Element {
     let href = `//${domain}${props.to}`;
 
     if (ref && ref !== 'HEAD') {
-      href = `//${domain}/~${ref}${props.to}`;
+      href = `//${domain}/~${encodeURIComponent(ref)}${props.to}`;
     }
 
     const formattedPathname = pathname.replace(`/${owner}/${repo}`, '') || '/';

--- a/website/app/context.tsx
+++ b/website/app/context.tsx
@@ -43,7 +43,7 @@ export function useBaseUrl(): string {
   let url = '/';
 
   if (ref && !domain) {
-    url += `${ref === 'HEAD' ? '' : `~${ref}`}`;
+    url += `${ref === 'HEAD' ? '' : `~${encodeURIComponent(ref)}`}`;
   }
 
   return url;
@@ -52,7 +52,7 @@ export function useBaseUrl(): string {
 export function useRepositoryUrl(): string {
   const { owner, repo, ref } = React.useContext(DocumentationContext);
 
-  return `https://github.com/${owner}/${repo}/tree/${ref}`;
+  return `https://github.com/${owner}/${repo}/tree/${encodeURIComponent(ref)}`;
 }
 
 export function useImagePath(src: string) {
@@ -77,12 +77,12 @@ export function useRawBlob(path: string): string {
 
   if (source.type === 'branch') {
     return `https://raw.githubusercontent.com/${owner}/${repo}/${
-      ref ?? baseBranch
+      encodeURIComponent(ref ?? baseBranch)
     }/docs${ensureLeadingSlash(path)}`;
   }
   if (source.type === 'PR') {
     return `https://raw.githubusercontent.com/${owner}/${repo}/${
-      ref ?? baseBranch
+      encodeURIComponent(ref ?? baseBranch)
     }/docs${ensureLeadingSlash(path)}`;
   }
 

--- a/website/app/context.tsx
+++ b/website/app/context.tsx
@@ -76,14 +76,14 @@ export function useRawBlob(path: string): string {
   const { owner, repository: repo, ref } = source;
 
   if (source.type === 'branch') {
-    return `https://raw.githubusercontent.com/${owner}/${repo}/${
-      encodeURIComponent(ref ?? baseBranch)
-    }/docs${ensureLeadingSlash(path)}`;
+    return `https://raw.githubusercontent.com/${owner}/${repo}/${encodeURIComponent(
+      ref ?? baseBranch,
+    )}/docs${ensureLeadingSlash(path)}`;
   }
   if (source.type === 'PR') {
-    return `https://raw.githubusercontent.com/${owner}/${repo}/${
-      encodeURIComponent(ref ?? baseBranch)
-    }/docs${ensureLeadingSlash(path)}`;
+    return `https://raw.githubusercontent.com/${owner}/${repo}/${encodeURIComponent(
+      ref ?? baseBranch,
+    )}/docs${ensureLeadingSlash(path)}`;
   }
 
   return `https://raw.githubusercontent.com/${owner}/${repo}/main/docs${ensureLeadingSlash(path)}`;

--- a/website/app/utils/config.ts
+++ b/website/app/utils/config.ts
@@ -164,7 +164,9 @@ export async function getConfiguration({
   const host =
     process.env.NODE_ENV === 'production' ? 'https://api.docs.page' : 'http://localhost:8000';
 
-  const endpoint = `${host}/config?owner=${owner}&repository=${repo}${ref ? `&ref=${encodeURIComponent(ref)}` : ''}`;
+  const endpoint = `${host}/config?owner=${owner}&repository=${repo}${
+    ref ? `&ref=${encodeURIComponent(ref)}` : ''
+  }`;
   try {
     const res = await (await fetch(endpoint)).json();
     config = res.config;

--- a/website/app/utils/config.ts
+++ b/website/app/utils/config.ts
@@ -164,7 +164,7 @@ export async function getConfiguration({
   const host =
     process.env.NODE_ENV === 'production' ? 'https://api.docs.page' : 'http://localhost:8000';
 
-  const endpoint = `${host}/config?owner=${owner}&repository=${repo}${ref ? `&ref=${ref}` : ''}`;
+  const endpoint = `${host}/config?owner=${owner}&repository=${repo}${ref ? `&ref=${encodeURIComponent(ref)}` : ''}`;
   try {
     const res = await (await fetch(endpoint)).json();
     config = res.config;


### PR DESCRIPTION
Try click any links here: https://docs.widgetbook.io/~feat%2fdocs-page - and you'll notice they 404 - since the ref has `/` which isn't uri encoded

