### PR TITLE
feat: support html comments in mdx files

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -35,6 +35,7 @@
     "rehype-accessible-emojis": "^0.3.2",
     "rehype-katex": "^6.0.2",
     "rehype-slug": "^5.0.0",
+    "remark-comment": "^1.0.0",
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
     "remark-parse": "^10.0.1",

--- a/api/src/utils/getPlugins.ts
+++ b/api/src/utils/getPlugins.ts
@@ -8,12 +8,13 @@ import rehypeSlug from 'rehype-slug';
 import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import { OutputConfig } from '@docs.page/server';
+import remarkComment from 'remark-comment';
 
 function getPlugins(config: OutputConfig) {
   //
   const remarkPlugins = config?.experimentalCodehike
-    ? [remarkGfm, [remarkCodeHike, { theme, lineNumbers: true }]]
-    : [remarkGfm];
+    ? [remarkGfm, remarkComment, [remarkCodeHike, { theme, lineNumbers: true }]]
+    : [remarkGfm, remarkComment];
 
   const rehypePlugins = config?.experimentalCodehike
     ? [rehypeSlug, rehypeInlineBadges, rehypeAccessibleEmojis]

--- a/yarn.lock
+++ b/yarn.lock
@@ -7086,7 +7086,7 @@ micromark-factory-whitespace@^1.0.0:
     micromark-util-symbol "^1.0.0"
     micromark-util-types "^1.0.0"
 
-micromark-util-character@^1.0.0:
+micromark-util-character@^1.0.0, micromark-util-character@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/micromark-util-character/-/micromark-util-character-1.1.0.tgz#d97c54d5742a0d9611a68ca0cd4124331f264d86"
   integrity sha512-agJ5B3unGNJ9rJvADMJ5ZiYjBRyDpzKAOk01Kpi1TKhlT1APx3XZk6eN7RtSz1erbWHC2L8T3xLZ81wdtGRZzg==
@@ -7191,7 +7191,7 @@ micromark-util-subtokenize@^1.0.0:
     micromark-util-types "^1.0.0"
     uvu "^0.5.0"
 
-micromark-util-symbol@^1.0.0:
+micromark-util-symbol@^1.0.0, micromark-util-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/micromark-util-symbol/-/micromark-util-symbol-1.0.1.tgz#b90344db62042ce454f351cf0bebcc0a6da4920e"
   integrity sha512-oKDEMK2u5qqAptasDAwWDXq0tG9AssVwAx3E9bBF3t/shRIGsWIRG+cGafs2p/SnDSOecnt6hZPCE2o6lHfFmQ==
@@ -8743,6 +8743,15 @@ rehype-slug@^5.0.0:
     hast-util-to-string "^2.0.0"
     unified "^10.0.0"
     unist-util-visit "^4.0.0"
+
+remark-comment@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/remark-comment/-/remark-comment-1.0.0.tgz#befe2fd5dde688d641542cd1206130e00b79a337"
+  integrity sha512-k8YPo5MGvl8l4gGxOH6Zk4Fa2AhDACN5eqKnKZcHDORZQS15hlnezlBHj2lqyDiqzApNmYOMTibkEJbMSKU25w==
+  dependencies:
+    micromark-factory-space "^1.0.0"
+    micromark-util-character "^1.1.0"
+    micromark-util-symbol "^1.0.1"
 
 remark-frontmatter@^4.0.0, remark-frontmatter@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
This PR adds support for `<!--html comments like this -->` .

Currently such comments are supported on Github, but make docs.page 500, for example: https://github.com/invertase/react-native-google-mobile-ads/issues/144