### PR TITLE
feat: add GTM and GA support

### DIFF
--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -31,6 +31,8 @@ export interface ConfigWithoutLocales {
   // Adds Google Tag Manager to your documentation pages.
   googleTagManager: string;
   // Whether zoomable images are enabled by default
+  googleAnalytics: string;
+  // Whether zoomable images are enabled by default
   zoomImages: boolean;
   // Whether CodeHike is enabled
   experimentalCodehike: boolean;
@@ -71,6 +73,8 @@ export interface ConfigWithLocales {
   variables: Record<string, string>;
   // Adds Google Tag Manager to your documentation pages.
   googleTagManager: string;
+  // Adds Google Analytics to your documentation pages.
+  googleAnalytics: string;
   // Whether zoomable images are enabled by default
   zoomImages: boolean;
   // Whether CodeHike is enabled
@@ -119,6 +123,8 @@ export interface OutputConfig {
   variables: Record<string, string>;
   // Adds Google Tag Manager to your documentation pages.
   googleTagManager: string;
+  // Adds Google Analytics to your documentation pages.
+  googleAnalytics: string;
   // Whether zoomable images are enabled by default
   zoomImages: boolean;
   // Whether CodeHike is enabled
@@ -141,6 +147,7 @@ export const defaultConfig: OutputConfig = {
   headerDepth: 3,
   variables: {},
   googleTagManager: '',
+  googleAnalytics: '',
   zoomImages: false,
   experimentalCodehike: false,
   experimentalMath: false,

--- a/website/app/components/Head.tsx
+++ b/website/app/components/Head.tsx
@@ -1,7 +1,6 @@
 import { Helmet } from 'react-helmet';
 import { DocumentationLoader } from '~/loaders/documentation.server';
 import codeHikeStyles from '@code-hike/mdx/dist/index.css';
-import { useEffect } from 'react';
 
 export const Head = ({ data }: { data: DocumentationLoader }) => {
   const favicon = getFavicon({ data });

--- a/website/app/components/Head.tsx
+++ b/website/app/components/Head.tsx
@@ -6,52 +6,51 @@ import { useEffect } from 'react';
 export const Head = ({ data }: { data: DocumentationLoader }) => {
   const favicon = getFavicon({ data });
 
-
   useEffect(() => {
     if (data.config.googleTagManager) {
       const tagScript = document.createElement('noscript');
       const tagIframe = document.createElement('iframe');
       tagIframe.src = `https://www.googletagmanager.com/ns.html?id=${data.config.googleTagManager}`;
-      tagIframe.height = "0";
-      tagIframe.width = "0";
-      tagIframe.style.display = "none";
-      tagIframe.style.visibility = "hidden";
+      tagIframe.height = '0';
+      tagIframe.width = '0';
+      tagIframe.style.display = 'none';
+      tagIframe.style.visibility = 'hidden';
 
       tagScript.appendChild(tagIframe);
-      document.body.insertBefore(tagScript, document.body.firstChild)
+      document.body.insertBefore(tagScript, document.body.firstChild);
     }
-  }, [])
+  }, []);
 
   return (
     <Helmet>
-      {data.config.googleAnalytics &&
-        <script async src={`https://www.googletagmanager.com/gtag/js?id=${data.config.googleAnalytics}`}></script>
-      }
-      {
-        data.config.googleAnalytics &&
-        <script type='text/javascript'>
-          {
-            `
+      {data.config.googleAnalytics && (
+        <script
+          async
+          src={`https://www.googletagmanager.com/gtag/js?id=${data.config.googleAnalytics}`}
+        ></script>
+      )}
+      {data.config.googleAnalytics && (
+        <script type="text/javascript">
+          {`
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
               gtag('js', new Date());
             
               gtag('config', '${data.config.googleAnalytics}');
-            `
-          }
+            `}
         </script>
-      }
-      {data.config.googleTagManager && <script type='text/javascript'>
-        {
-          `
+      )}
+      {data.config.googleTagManager && (
+        <script type="text/javascript">
+          {`
           (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
           new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
           j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
           'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
           })(window,document,'script','dataLayer','${data.config.googleTagManager}');
-          `
-        }
-      </script>}
+          `}
+        </script>
+      )}
       <link rel="icon" href={favicon} />
       {data.config.experimentalMath && (
         <link

--- a/website/app/components/Head.tsx
+++ b/website/app/components/Head.tsx
@@ -1,11 +1,57 @@
 import { Helmet } from 'react-helmet';
 import { DocumentationLoader } from '~/loaders/documentation.server';
 import codeHikeStyles from '@code-hike/mdx/dist/index.css';
+import { useEffect } from 'react';
 
 export const Head = ({ data }: { data: DocumentationLoader }) => {
   const favicon = getFavicon({ data });
+
+
+  useEffect(() => {
+    if (data.config.googleTagManager) {
+      const tagScript = document.createElement('noscript');
+      const tagIframe = document.createElement('iframe');
+      tagIframe.src = `https://www.googletagmanager.com/ns.html?id=${data.config.googleTagManager}`;
+      tagIframe.height = "0";
+      tagIframe.width = "0";
+      tagIframe.style.display = "none";
+      tagIframe.style.visibility = "hidden";
+
+      tagScript.appendChild(tagIframe);
+      document.body.insertBefore(tagScript, document.body.firstChild)
+    }
+  }, [])
+
   return (
     <Helmet>
+      {data.config.googleAnalytics &&
+        <script async src={`https://www.googletagmanager.com/gtag/js?id=${data.config.googleAnalytics}`}></script>
+      }
+      {
+        data.config.googleAnalytics &&
+        <script type='text/javascript'>
+          {
+            `
+              window.dataLayer = window.dataLayer || [];
+              function gtag(){dataLayer.push(arguments);}
+              gtag('js', new Date());
+            
+              gtag('config', '${data.config.googleAnalytics}');
+            `
+          }
+        </script>
+      }
+      {data.config.googleTagManager && <script type='text/javascript'>
+        {
+          `
+          (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+          new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+          j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+          'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+          })(window,document,'script','dataLayer','${data.config.googleTagManager}');
+          `
+        }
+      </script>}
       <link rel="icon" href={favicon} />
       {data.config.experimentalMath && (
         <link

--- a/website/app/components/Head.tsx
+++ b/website/app/components/Head.tsx
@@ -6,21 +6,6 @@ import { useEffect } from 'react';
 export const Head = ({ data }: { data: DocumentationLoader }) => {
   const favicon = getFavicon({ data });
 
-  useEffect(() => {
-    if (data.config.googleTagManager) {
-      const tagScript = document.createElement('noscript');
-      const tagIframe = document.createElement('iframe');
-      tagIframe.src = `https://www.googletagmanager.com/ns.html?id=${data.config.googleTagManager}`;
-      tagIframe.height = '0';
-      tagIframe.width = '0';
-      tagIframe.style.display = 'none';
-      tagIframe.style.visibility = 'hidden';
-
-      tagScript.appendChild(tagIframe);
-      document.body.insertBefore(tagScript, document.body.firstChild);
-    }
-  }, []);
-
   return (
     <Helmet>
       {data.config.googleAnalytics && (

--- a/website/app/utils/config.ts
+++ b/website/app/utils/config.ts
@@ -135,10 +135,10 @@ export function mergeConfig(json: Record<string, unknown>): ProjectConfig {
     theme: getString(json, 'theme', defaultConfig.theme),
     docsearch: getValue(json, 'docsearch')
       ? {
-        appId: getString(json, 'docsearch.appId', ''),
-        apiKey: getString(json, 'docsearch.apiKey', ''),
-        indexName: getString(json, 'docsearch.indexName', ''),
-      }
+          appId: getString(json, 'docsearch.appId', ''),
+          apiKey: getString(json, 'docsearch.apiKey', ''),
+          indexName: getString(json, 'docsearch.indexName', ''),
+        }
       : defaultConfig.docsearch,
     // navigation: mergeNavigationConfig(json),
     sidebar: mergeSidebarConfig(json),
@@ -168,8 +168,9 @@ export async function getConfiguration({
   const host =
     process.env.NODE_ENV === 'production' ? 'https://api.docs.page' : 'http://localhost:8000';
 
-  const endpoint = `${host}/config?owner=${owner}&repository=${repo}${ref ? `&ref=${encodeURIComponent(ref)}` : ''
-    }`;
+  const endpoint = `${host}/config?owner=${owner}&repository=${repo}${
+    ref ? `&ref=${encodeURIComponent(ref)}` : ''
+  }`;
   try {
     const res = await (await fetch(endpoint)).json();
     config = res.config;

--- a/website/app/utils/config.ts
+++ b/website/app/utils/config.ts
@@ -92,6 +92,8 @@ export interface ProjectConfig {
   variables: Record<string, string>;
   // Adds Google Tag Manager to your documentation pages.
   googleTagManager: string;
+  // Adds Google Analytics to your documentation pages.
+  googleAnalytics: string;
   // Whether zoomable images are enabled by default
   zoomImages: boolean;
   // Whether CodeHike is enabled
@@ -114,6 +116,7 @@ export const defaultConfig: ProjectConfig = {
   headerDepth: 3,
   variables: {},
   googleTagManager: '',
+  googleAnalytics: '',
   zoomImages: false,
   experimentalCodehike: false,
   experimentalMath: false,
@@ -132,16 +135,17 @@ export function mergeConfig(json: Record<string, unknown>): ProjectConfig {
     theme: getString(json, 'theme', defaultConfig.theme),
     docsearch: getValue(json, 'docsearch')
       ? {
-          appId: getString(json, 'docsearch.appId', ''),
-          apiKey: getString(json, 'docsearch.apiKey', ''),
-          indexName: getString(json, 'docsearch.indexName', ''),
-        }
+        appId: getString(json, 'docsearch.appId', ''),
+        apiKey: getString(json, 'docsearch.apiKey', ''),
+        indexName: getString(json, 'docsearch.indexName', ''),
+      }
       : defaultConfig.docsearch,
     // navigation: mergeNavigationConfig(json),
     sidebar: mergeSidebarConfig(json),
     headerDepth: getNumber(json, 'headerDepth', defaultConfig.headerDepth),
     variables: getValue(json, 'variables', defaultConfig.variables) as Record<string, string>,
     googleTagManager: getString(json, 'googleTagManager', defaultConfig.googleTagManager),
+    googleAnalytics: getString(json, 'googleAnalytics', defaultConfig.googleAnalytics),
     zoomImages: getBoolean(json, 'zoomImages', defaultConfig.zoomImages),
     // TODO: tidy the following:
     locales: (json.locales as Record<string, string>) ?? undefined,
@@ -164,9 +168,8 @@ export async function getConfiguration({
   const host =
     process.env.NODE_ENV === 'production' ? 'https://api.docs.page' : 'http://localhost:8000';
 
-  const endpoint = `${host}/config?owner=${owner}&repository=${repo}${
-    ref ? `&ref=${encodeURIComponent(ref)}` : ''
-  }`;
+  const endpoint = `${host}/config?owner=${owner}&repository=${repo}${ref ? `&ref=${encodeURIComponent(ref)}` : ''
+    }`;
   try {
     const res = await (await fetch(endpoint)).json();
     config = res.config;


### PR DESCRIPTION
This PR adds support for google analytics and google tag manager, which is missing in v2, as raised in https://github.com/invertase/docs.page/issues/209