### PR TITLE
feat(previous-next): add frontmatter arguments for automatically displaying next and previous buttons

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -194,8 +194,8 @@ If provided, Google Tag Manager will be added to all of your documentation pages
 
 If provided, Google Analytics will be added to all of your documentation pages.
 
-| Key                | Type     | Default |
-| ------------------ | -------- | ------- |
+| Key               | Type     | Default |
+| ----------------- | -------- | ------- |
 | `googleAnalytics` | `string` |         |
 
 ### `zoomImages`

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -114,6 +114,15 @@ For example:
 }
 ```
 
+### `automaticallyInferNextPrevious`
+
+A boolean indicating if the next and previous links should be automatically inferred from the sidebar configuration.
+You can still overwrite a specific link by providing the `next` and `previous` keys in the [frontmatter](/frontmatter).
+
+| Key                              | Type      | Default |
+| -------------------------------- | --------- | ------- |
+| `automaticallyInferNextPrevious` | `boolean` | `true`  |
+
 ### `sidebar`
 
 An array containing nested sidebar array items. If provided, will be rendered on every page down the left hand side.

--- a/docs/frontmatter.mdx
+++ b/docs/frontmatter.mdx
@@ -75,3 +75,43 @@ redirect: /getting-started
 redirect: https://github.com/acme/awesome-project
 ---
 ```
+
+## previous
+
+A path which if set, will show a link to the previous page at the bottom of the page.
+If the previousTitle is not set, the title will be get from the `docs.json`.
+If not found in the configuration file, an empty string will be used.
+
+Can be a relative internal path or external URL.
+
+| Key             | Type     | Default                                               |
+| --------------- | -------- | ----------------------------------------------------- |
+| `previous`      | `string` |                                                       |
+| `previousTitle` | `string` | The value for the previous path in the docs.json file |
+
+```text title=index.md
+---
+previous: /getting-started
+previousTitle: Getting started
+---
+```
+
+## next
+
+A path which if set, will show a link to the next page at the bottom of the page.
+If the nextTitle is not set, the title will be get from the `docs.json`.
+If not found in the configuration file, an empty string will be used.
+
+Can be a relative internal path or external URL.
+
+| Key         | Type     | Default                                           |
+| ----------- | -------- | ------------------------------------------------- |
+| `next`      | `string` |                                                   |
+| `nextTitle` | `string` | The value for the next path in the docs.json file |
+
+```text title=index.md
+---
+next: /getting-started
+nextTitle: Getting started
+---
+```

--- a/website/app/components/Documentation.tsx
+++ b/website/app/components/Documentation.tsx
@@ -1,20 +1,21 @@
 import { useHydratedMdx } from '@docs.page/client';
 import cx from 'classnames';
 
-import { Footer } from '~/components/Footer';
-import { Header } from '~/components/Header';
-import { Sidebar } from '~/components/Sidebar';
-import { Theme } from '~/components/Theme';
-import components from '~/components/mdx';
-import { DocumentationProvider, DomainProvider } from '~/context';
-import { DocumentationLoader } from '../loaders/documentation.server';
-import { ScrollSpy } from '~/components/ScrollSpy';
-import { TabsContext } from './mdx/Tabs';
-import { hash as createHash } from '~/utils';
-import { MobileNav } from './MobileNav';
 import { useEffect, useState } from 'react';
 import { useTransition } from 'remix';
+import { Footer } from '~/components/Footer';
+import { Header } from '~/components/Header';
+import components from '~/components/mdx';
+import { ScrollSpy } from '~/components/ScrollSpy';
+import { Sidebar } from '~/components/Sidebar';
+import { Theme } from '~/components/Theme';
+import { DocumentationProvider, DomainProvider } from '~/context';
+import { hash as createHash } from '~/utils';
 import domains from '../../../domains.json';
+import { DocumentationLoader } from '../loaders/documentation.server';
+import { TabsContext } from './mdx/Tabs';
+import { MobileNav } from './MobileNav';
+import { PreviousNext } from './PreviousNext';
 
 export default function Documentation({ data }: { data: DocumentationLoader }) {
   const [open, toggleMenu] = useState<boolean>(false);
@@ -58,6 +59,8 @@ export default function Documentation({ data }: { data: DocumentationLoader }) {
                   <TabsContext hash={hash}>
                     <MDX components={components} />
                   </TabsContext>
+
+                  <PreviousNext frontmatter={data.frontmatter} />
                 </main>
                 <Footer />
               </div>

--- a/website/app/components/PreviousNext.tsx
+++ b/website/app/components/PreviousNext.tsx
@@ -1,0 +1,63 @@
+import { BundleSuccess, SidebarItem } from '@docs.page/server';
+import { useDocumentationContext } from '~/context';
+import { DocsLink } from './DocsLink';
+
+interface PreviousNextProps {
+  frontmatter: BundleSuccess['frontmatter'];
+}
+
+function findNameInSidebar(sidebarItems: SidebarItem[], url: string): string | undefined {
+  for (const item of sidebarItems) {
+    const [title, urlOrChildren] = item;
+    if (typeof urlOrChildren === 'string') {
+      if (urlOrChildren === url) {
+        return title as string;
+      }
+    } else {
+      const name = findNameInSidebar(urlOrChildren, url);
+      if (name) {
+        return name;
+      }
+    }
+  }
+}
+
+export function PreviousNext({ frontmatter }: PreviousNextProps) {
+  const previous = frontmatter.previous;
+  const next = frontmatter.next;
+
+  const previousTitle = frontmatter.previousTitle;
+  const nextTitle = frontmatter.nextTitle;
+
+  const { sidebar } = useDocumentationContext().config;
+
+  if (!previous && !next) {
+    return null;
+  }
+
+  return (
+    <nav aria-label="Docs pages navigation" className="mt-10 flex items-center justify-between">
+      {!!previous && (
+        <DocsLink
+          to={previous}
+          className="transition-border rounded-md border p-4 no-underline hover:border-gray-300"
+        >
+          <div className="text-sm text-gray-600 dark:text-gray-200">Previous</div>
+          <div className="text-docs-theme">
+            « {previousTitle ?? findNameInSidebar(sidebar, previous)}
+          </div>
+        </DocsLink>
+      )}
+      <div />
+      {!!next && (
+        <DocsLink
+          to={next}
+          className="transition-border rounded-md border p-4 text-right no-underline hover:border-gray-300"
+        >
+          <div className="text-sm text-gray-600 dark:text-gray-200">Next</div>
+          <div className="text-docs-theme">{nextTitle ?? findNameInSidebar(sidebar, next)} »</div>
+        </DocsLink>
+      )}
+    </nav>
+  );
+}

--- a/website/app/utils/config.ts
+++ b/website/app/utils/config.ts
@@ -1,5 +1,5 @@
-import { getBoolean, getNumber, getString, getValue } from './get';
 import get from 'lodash.get';
+import { getBoolean, getNumber, getString, getValue } from './get';
 
 // Represents how the sidebar should look in the config file.
 export type SidebarItem = [string, Array<[string, string]>] | [string, string];
@@ -100,6 +100,8 @@ export interface ProjectConfig {
   experimentalCodehike: boolean;
   // Whether Math is enabled
   experimentalMath: boolean;
+  // Whether Next/Previous buttons are showing automatically based on the sidebar
+  automaticallyInferNextPrevious: boolean;
 }
 
 export const defaultConfig: ProjectConfig = {
@@ -120,6 +122,7 @@ export const defaultConfig: ProjectConfig = {
   zoomImages: false,
   experimentalCodehike: false,
   experimentalMath: false,
+  automaticallyInferNextPrevious: true,
 };
 
 // Merges any user config with default values.
@@ -155,6 +158,11 @@ export function mergeConfig(json: Record<string, unknown>): ProjectConfig {
       defaultConfig.experimentalCodehike,
     ),
     experimentalMath: getBoolean(json, 'experimentalMath', defaultConfig.experimentalMath),
+    automaticallyInferNextPrevious: getBoolean(
+      json,
+      'automaticallyInferNextPrevious',
+      defaultConfig.automaticallyInferNextPrevious,
+    ),
   };
 }
 


### PR DESCRIPTION
# Motivation 
I used docs.page for my Location plugin doc, and when seeing the documentation on Mobile, it felt weird that a Previous/Next was missing
I [added it manually](https://docs.page/Lyokone/flutterlocation/features/get-location) with HTML but I was thinking that we could parse the frontmatter to easily add those.

# Result
The end result looks like this:
<img width="389" alt="Screenshot 2022-06-17 at 14 50 51" src="https://user-images.githubusercontent.com/3680002/174301770-20b28c58-9263-48cb-9912-61ef7aa6eedc.png">
<img width="1121" alt="Screenshot 2022-06-17 at 14 50 47" src="https://user-images.githubusercontent.com/3680002/174301775-58aa8a34-b64e-475b-9ac5-59ecc15c2579.png">

