### PR TITLE
feat: support console language option in highlighting

### DIFF
--- a/api/src/bundler/plugins/rehype-code-blocks.ts
+++ b/api/src/bundler/plugins/rehype-code-blocks.ts
@@ -18,11 +18,19 @@ export default function rehypeCodeBlocks(): (ast: Node) => void {
     }
 
     const language = getLanguage(node);
+
     const raw = toString(node);
 
-    // Raw value of the `code` block - used for copy/paste
-    parent.properties['raw'] = raw;
-    parent.properties['html'] = highlighter.codeToHtml(raw, language);
+    // If the user provides the `console` language, we add the 'shell' language and remove $ from the raw code, for copying purposes.
+    if (language === 'console') {
+      const removedDollarSymbol = raw.replace(/^(^ *)\$/g, '');
+
+      parent.properties['raw'] = removedDollarSymbol;
+      parent.properties['html'] = highlighter.codeToHtml(raw, { lang: 'shell' });
+    } else {
+      parent.properties['raw'] = raw;
+      parent.properties['html'] = highlighter.codeToHtml(raw, { lang: language });
+    }
 
     // Get any metadata from the code block
     const meta = (node.data?.meta as string) ?? '';

--- a/website/app/entry.client.tsx
+++ b/website/app/entry.client.tsx
@@ -19,13 +19,8 @@ if (
   delete window.__remixManifest.routes['routes/preview-fetch'];
 }
 
-const container = document.getElementById('app');
-if (!container) {
-  throw new Error('No element with id "app" found');
-}
-
 hydrateRoot(
-  container,
+  document,
   <BrowserRouter>
     <RemixBrowser />
   </BrowserRouter>,


### PR DESCRIPTION
This PR adds support for `console` as a language choice in mdx code blocks, as requested in https://github.com/invertase/docs.page/issues/232 

It also fixes a bug on `next` preventing client side rendering.