### PR TITLE
fix: correct the link to edit this page on index files

### DIFF
--- a/api/src/utils/bundle.ts
+++ b/api/src/utils/bundle.ts
@@ -115,6 +115,7 @@ export class Bundle {
       throw new BundleError(404, "Couldn't find file", 'FILE_NOT_FOUND');
     }
     this.markdown = githubContents.md;
+    this.path = githubContents.path;
     this.contentFetched = true;
   }
 

--- a/api/src/utils/config.ts
+++ b/api/src/utils/config.ts
@@ -155,9 +155,9 @@ export function formatConfigLocales(configFiles: Configs, path: string): OutputC
   ) {
     // TODO: edge cases of bad configs, e.g what if locales is not an array?
 
-    const defaulLocale = config.locales[0];
+    const defaultLocale = config.locales[0];
 
-    const currentLocale = path.split('/')[0] || defaulLocale;
+    const currentLocale = path.split('/')[0] || defaultLocale;
 
     const sidebar = (getValue(config, 'sidebar') as Record<string, unknown>)[currentLocale];
 


### PR DESCRIPTION
This makes sure the correct link is added in the "Edit this page" button, which was broken for `index.mdx` files.