### PR TITLE
feat: add the ability to specify custom domains for self hosted Plausible instances

### DIFF
--- a/api/src/utils/config.ts
+++ b/api/src/utils/config.ts
@@ -1,9 +1,9 @@
-import { getBoolean, getNumber, getString, getValue } from './get.js';
 import get from 'lodash.get';
+import { getBoolean, getNumber, getString, getValue } from './get.js';
 
-import yaml from 'js-yaml';
-import toml from '@ltd/j-toml';
 import { OutputConfig } from '@docs.page/server';
+import toml from '@ltd/j-toml';
+import yaml from 'js-yaml';
 
 // Represents how the sidebar should look in the config file.
 export type SidebarItem = [string, Array<[string, string]>] | [string, string];
@@ -82,6 +82,7 @@ export const defaultConfig: OutputConfig = {
   experimentalMath: false,
   automaticallyInferNextPrevious: true,
   plausibleAnalytics: false,
+  plausibleAnalyticsScript: 'https://plausible.io/js/script.js',
 };
 
 // Merges any user config with default values.
@@ -123,6 +124,11 @@ export function mergeConfig(json: Record<string, unknown>): OutputConfig {
       defaultConfig.automaticallyInferNextPrevious,
     ),
     plausibleAnalytics: getBoolean(json, 'plausibleAnalytics', defaultConfig.plausibleAnalytics),
+    plausibleAnalyticsScript: getString(
+      json,
+      'plausibleAnalyticsScript',
+      defaultConfig.plausibleAnalyticsScript,
+    ),
   };
 }
 

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -224,3 +224,11 @@ If enabled, Plausible Analytics will be added to all of your documentation pages
 | Key                  | Type      | Default |
 | -------------------- | --------- | ------- |
 | `plausibleAnalytics` | `boolean` | `false` |
+
+### `plausibleAnalyticsScript`
+
+If provided, Plausible Analytics will use a custom script for sending informations. This is useful if you are using a self-hosted instance of Plausible Analytics
+
+| Key                        | Type     | Default                             |
+| -------------------------- | -------- | ----------------------------------- |
+| `plausibleAnalyticsScript` | `string` | `https://plausible.io/js/script.js` |

--- a/packages/server/src/types.ts
+++ b/packages/server/src/types.ts
@@ -42,6 +42,8 @@ export interface ConfigWithoutLocales {
   automaticallyInferNextPrevious: boolean;
   // Adds Plausible Analytics to your documentation pages.
   plausibleAnalytics: string;
+  // Specify the Plausible Analytics script to use
+  plausibleAnalyticsScript: string;
 }
 
 export interface ConfigWithLocales {
@@ -89,6 +91,8 @@ export interface ConfigWithLocales {
   automaticallyInferNextPrevious: boolean;
   // Adds Plausible Analytics to your documentation pages.
   plausibleAnalytics: string;
+  // Specify the Plausible Analytics script to use
+  plausibleAnalyticsScript: string;
 }
 export type InputConfig = ConfigWithoutLocales | ConfigWithLocales;
 
@@ -143,6 +147,8 @@ export interface OutputConfig {
   automaticallyInferNextPrevious: boolean;
   // Adds Plausible Analytics to your documentation pages.
   plausibleAnalytics: boolean;
+  // Specify the Plausible Analytics script to use
+  plausibleAnalyticsScript: string;
 }
 
 export const defaultConfig: OutputConfig = {
@@ -165,6 +171,7 @@ export const defaultConfig: OutputConfig = {
   experimentalMath: false,
   automaticallyInferNextPrevious: true,
   plausibleAnalytics: false,
+  plausibleAnalyticsScript: 'https://plausible.io/js/script.js',
 };
 
 export type FetchBundleInput = {

--- a/website-v3/src/bundle.ts
+++ b/website-v3/src/bundle.ts
@@ -29,6 +29,7 @@ const $BundleConfig = z.object({
   experimentalMath: z.boolean(),
   automaticallyInferNextPrevious: z.boolean(),
   plausibleAnalytics: z.boolean().optional(),
+  plausibleAnalyticsScript: z.string().optional(),
 });
 
 const $GetBundleRequest = z.object({

--- a/website-v3/src/components/Scripts.astro
+++ b/website-v3/src/components/Scripts.astro
@@ -40,6 +40,6 @@ const { domain, config } = context.get();
 }
 {
   config.plausibleAnalytics && domain && (
-    <script slot="head" defer data-domain={domain} src="https://plausible.io/js/plausible.js" />
+    <script slot="head" defer data-domain={domain} src={config.plausibleAnalyticsScript} />
   )
 }

--- a/website/app/components/Head.tsx
+++ b/website/app/components/Head.tsx
@@ -1,7 +1,7 @@
-import { Helmet } from 'react-helmet';
-import { DocumentationLoader } from '~/loaders/documentation.server';
 import codeHikeStyles from '@code-hike/mdx/dist/index.css';
+import { Helmet } from 'react-helmet';
 import { useCustomDomain, useImagePath } from '~/context';
+import { DocumentationLoader } from '~/loaders/documentation.server';
 
 export const Head = ({ data }: { data: DocumentationLoader }) => {
   const favicon = useImagePath(data.config.favicon || 'https://docs.page/favicon.ico?v=2');
@@ -38,7 +38,7 @@ export const Head = ({ data }: { data: DocumentationLoader }) => {
         </script>
       )}
       {data.config.plausibleAnalytics && domain && (
-        <script defer data-domain={domain} src="https://plausible.io/js/plausible.js"></script>
+        <script defer data-domain={domain} src={data.config.plausibleAnalyticsScript}></script>
       )}
       <link rel="icon" href={favicon} />
       {data.config.experimentalMath && (


### PR DESCRIPTION
I've added the `plausibleAnalyticsScript` to specify the script's domain for self-hosted instances of Plausible.
I've also modified the default domain from `https://plausible.io/js/plausible.js` to `https://plausible.io/js/script.js` as per [documentation](https://plausible.io/docs/plausible-script). 