### PR TITLE
feat: add the ability to specify custom domains for self hosted Plaus…

### DIFF
--- a/api/src/utils/config.ts
+++ b/api/src/utils/config.ts
@@ -41,6 +41,7 @@ const $Config = z
     automaticallyDisplayName: z.boolean().catch(true),
     automaticallyInferNextPrevious: z.boolean().catch(true),
     plausibleAnalytics: z.boolean().catch(false),
+    plausibleAnalyticsScript: z.boolean().catch('https://plausible.io/js/script.js'),
     anchors: z
       .array(
         z

--- a/api/src/utils/config.ts
+++ b/api/src/utils/config.ts
@@ -41,7 +41,7 @@ const $Config = z
     automaticallyDisplayName: z.boolean().catch(true),
     automaticallyInferNextPrevious: z.boolean().catch(true),
     plausibleAnalytics: z.boolean().catch(false),
-    plausibleAnalyticsScript: z.boolean().catch('https://plausible.io/js/script.js'),
+    plausibleAnalyticsScript: z.string().catch('https://plausible.io/js/script.js'),
     anchors: z
       .array(
         z

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -172,12 +172,13 @@ If set to true, the [Plausible](https://plausible.io/) analytics script will be 
 <Warning>This property will only take effect when using a [custom domain](/custom-domains).</Warning>
 </Property>
 
+<hr />
+
 <Property name="plausibleAnalyticsScript" type="string" default="https://plausible.io/js/script.js">
 If set, the self-hosted [Plausible](https://plausible.io/) analytics script will be used.
 
 <Warning>This property will only take effect when `plausibleAnalytics` is set to `true`.</Warning>
 </Property>
-
 
 <hr />
 

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -172,6 +172,13 @@ If set to true, the [Plausible](https://plausible.io/) analytics script will be 
 <Warning>This property will only take effect when using a [custom domain](/custom-domains).</Warning>
 </Property>
 
+<Property name="plausibleAnalyticsScript" type="string" default="https://plausible.io/js/script.js">
+If set, the self-hosted [Plausible](https://plausible.io/) analytics script will be used.
+
+<Warning>This property will only take effect when `plausibleAnalytics` is set to `true`.</Warning>
+</Property>
+
+
 <hr />
 
 <Property name="anchors" type="Anchor[]">

--- a/website-v3/src/bundle.ts
+++ b/website-v3/src/bundle.ts
@@ -44,6 +44,7 @@ const $BundleConfig = z.object({
   automaticallyInferNextPrevious: z.boolean(),
   automaticallyDisplayName: z.boolean(),
   plausibleAnalytics: z.boolean(),
+  plausibleAnalyticsScript: z.string(),
 });
 
 const $GetBundleRequest = z.object({

--- a/website-v3/src/components/Scripts.astro
+++ b/website-v3/src/components/Scripts.astro
@@ -233,6 +233,6 @@ const { config, domain } = ctx;
 }
 {
   config.plausibleAnalytics && domain && (
-    <script slot="head" defer data-domain={domain} src="https://plausible.io/js/plausible.js" />
+    <script slot="head" defer data-domain={domain} src={config.plausibleAnalyticsScript} />
   )
 }


### PR DESCRIPTION
I've added the plausibleAnalyticsScript to specify the script's domain for self-hosted instances of Plausible.
I've also modified the default domain from https://plausible.io/js/plausible.js to https://plausible.io/js/script.js as per [documentation](https://plausible.io/docs/plausible-script).