### PR TITLE
docs: add example for `anchors` in YAML format

### DIFF
--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -196,14 +196,31 @@ type Anchor = {
 
 For the icons, you can use the name of any standard [Font Awesome Classic Icon](https://fontawesome.com/search?o=r&s=solid)
 or [Brand Icons](https://fontawesome.com/search?o=r&f=brands), for example:
-
-```json
-{
-  "anchors": [
-    { title: "Homepage", icon: "house", link: "https://example.com" }
-  ]
-}
-```
+  
+<Tabs
+  values={[
+    { label: 'JSON', value: 'json' },
+    { label: 'YAML', value: 'yaml' },
+  ]}
+>
+  <TabItem value="json">
+  ```json
+  {
+    "anchors": [
+      { title: "Homepage", icon: "house", link: "https://example.com" }
+    ]
+  }
+  ```
+  </TabItem>
+  <TabItem value="yaml">
+  ```yaml
+  anchors:
+  - title: "Homepage"
+    link: "https://example.com"
+    icon: "house"
+  ```
+  </TabItem>
+</Tabs>
 </Property>
 
 <hr />


### PR DESCRIPTION
Preview: https://use.docs.page/~277/configuration

## Before

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/24459435/222702752-c05d0978-1519-461f-9c95-cceb343ddce7.png">

## After

_JSON selected_

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/24459435/222702609-d10aae59-140d-4922-87af-79a1f39c66fb.png">

_YAML selected_

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/24459435/222702639-f8175f95-e562-4ef7-b6e8-08e03ccc59a4.png">

