### PR TITLE
feat: allow importing Zapps from other locations

### DIFF
--- a/docs/components/zapp.mdx
+++ b/docs/components/zapp.mdx
@@ -26,3 +26,50 @@ To prevent the sandbox from loading until the user interacts, pass the `lazy` pr
 ```
 
 <Zapp lazy id="flutter" />
+
+## From GitHub
+
+To load a Zapp! from GitHub, set the `id` prop to `github/<path>`.
+
+```jsx
+<Zapp id="github/roaa94/flutter_3d_calculator" />
+```
+
+<Zapp id="github/roaa94/flutter_3d_calculator" />
+
+You can also pass a path relative to the root of the repository.
+
+```jsx
+<Zapp id="github/rrousselGit/riverpod/tree/master/packages/flutter_riverpod/example" />
+```
+
+<Zapp id="github/rrousselGit/riverpod/tree/master/packages/flutter_riverpod/example" />
+
+## From GitHub Gists
+
+To load a Zapp! from a GitHub Gist, set the `id` prop to `gist/<id>`.
+
+Gist: 
+https://gist.github.com/flutterdevrelgists/ecabed4a17a3aad8bee7c6327e472fc8
+
+Zapp:
+```jsx
+<Zapp id="gist/ecabed4a17a3aad8bee7c6327e472fc8" />
+```
+
+Final product:
+<Zapp id="gist/ecabed4a17a3aad8bee7c6327e472fc8" />
+
+## From Pub
+
+To load a Zapp! from a https://pub.dev example, set the `id` prop to `pub/<package>` or `pub/<package>/<version>`.
+
+```jsx
+<Zapp id="pub/http" />
+
+<Zapp id="pub/http/0.13.4" />
+```
+
+<Zapp id="pub/http" />
+
+<Zapp id="pub/http/0.13.4" />

--- a/website-v3/src/components/mdx/Zapp.tsx
+++ b/website-v3/src/components/mdx/Zapp.tsx
@@ -9,12 +9,19 @@ const Zapp: React.FC<ZappProps> = props => {
     return <div />;
   }
 
+  // Allows for GitHub, Gist, and other Zapps.
+  // If no / is included, we assume the user supplied a Zapp id,
+  // like 'flutter', which should be prefixed by 'edit/'.
+  // Otherwise, we assume the user specified their own Zapp path,
+  // and treat it as such.
+  const id = props.id.includes('/') ? props.id : `edit/${props.id}`;
+
   const lazy = props.lazy === undefined ? false : props.lazy;
   const theme = props.theme || 'dark';
 
   return (
     <iframe
-      src={`https://zapp.run/embed/${props.id}?theme=${theme}&lazy=${lazy}`}
+      src={`https://zapp.run/${id}?theme=${theme}&lazy=${lazy}`}
       className="aspect-video w-full"
       style={{
         width: '100%',


### PR DESCRIPTION
Based on the current Zapp! docs: https://docs.zapp.run/features/share-and-embed

I toyed with the idea of adding a different prop for each type of import (i.e. `github=""`, `gist=""`, `pub=""`), but that seems less maintainable since you would need to add a new prop whenever Zapp supports a new import location, in addition to the attributes being mutually exclusive. Instead, the current method will work for any future Zapp imports, and does not have the mutual exclusivity issue.

Note: *I have not been able to test this locally!* The setup instructions in the contributing guide were not working for me. I would appreciate it if someone here could try this PR out locally. I also have never dabbled in JSX/TSX before so apologies if I did anything weird.