### PR TITLE
fix: parse private key before giving it to probot

### DIFF
--- a/api/src/probot.ts
+++ b/api/src/probot.ts
@@ -4,7 +4,7 @@ import { createNodeMiddleware, Probot, createProbot } from 'probot';
 const probot = createProbot({
   overrides: {
     appId: process.env.GITHUB_APP_ID,
-    privateKey: process.env.GITHUB_APP_PRIVATE_KEY,
+    privateKey: JSON.parse(`"${process.env.GITHUB_APP_PRIVATE_KEY}"`),
   },
 });
 


### PR DESCRIPTION
This PR should fix the github app, once relevant env variables are updated in deployments and on Github.