### PR TITLE
chore: add entry for rika2mqtt subdomain - Update domains.json

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -106,5 +106,9 @@
 	[
 		"docs.buildwiththeta.com",
 		"buildwiththeta/buildwiththeta"
+	],
+	[
+		"rika2mqtt.cookiecode.dev",
+		"sebastienvermeille/rika2mqtt"
 	]
 ]


### PR DESCRIPTION
According to the doc, I would like to add a custom domain for my documentation.

domain: `rika2mqtt.cookiecode.dev`
should point to project `sebastienvermeille/rika2mqtt`