### PR TITLE
chore: add entry for stepbuilder subdomain - Update domains.json

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -108,6 +108,10 @@
 		"buildwiththeta/buildwiththeta"
 	],
 	[
+		"stepbuilder.cookiecode.dev",
+		"sebastienvermeille/intellij-stepbuilder-codegen-plugin"
+	],
+	[
 		"rika2mqtt.cookiecode.dev",
 		"sebastienvermeille/rika2mqtt"
 	],


### PR DESCRIPTION
According to the doc, I would like to add a custom domain for my documentation.

domain: `stepbuilder.cookiecode.dev`
should point to project `sebastienvermeille/intellij-stepbuilder-codegen-plugin`