### PR TITLE
chore: Remove Pieces Docs from domains.json

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -100,10 +100,6 @@
 		"hyper-designed/box_transform"
 	],
 	[
-		"docs.pieces.app",
-		"pieces-app/documentation"
-	],
-	[
 		"news.pieces.app",
 		"pieces-app/news"
 	],


### PR DESCRIPTION
We are migrating our docs to Docusuarus but are keeping our news site on docs.page for the time being.