### PR TITLE
docs: Fix typo in previews.mdx

### DIFF
--- a/docs/previews.mdx
+++ b/docs/previews.mdx
@@ -34,7 +34,7 @@ as the first URL path prefixed with the `~` character, for example:
 
 ```txt
 // Branch ("next")
-hhttps://melos.invertase.dev/~next
+https://melos.invertase.dev/~next
 
 // Pull Request (#48)
 https://melos.invertase.dev/~48


### PR DESCRIPTION
Really stupid typo fix in `previews.mdx` 