### PR TITLE
chore: Adding Gazelle docs custom domain record

### DIFF
--- a/domains.json
+++ b/domains.json
@@ -154,5 +154,9 @@
 	[
 		"utils.kishormainali.com",
 		"kishormainali/fp_util"
+	],
+	[
+		"docs.gazelle-dart.dev",
+		"intales/gazelle"
 	]
 ]


### PR DESCRIPTION
This is our documentation domain for Gazelle,
our backend framework written in Dart.

Can you merge this? Would be awesome to have the docs linked to our domain :)
Thanks!