### PR TITLE
fix: incorrect link in language switcher

### DIFF
--- a/website/app/components/Link.tsx
+++ b/website/app/components/Link.tsx
@@ -3,10 +3,12 @@ import type { ComponentProps } from "react";
 import { useHref } from "~/context";
 import { isExternalLink } from "~/utils";
 
-type LinkProps = ComponentProps<"a">;
+type LinkProps = {
+  ignoreLocale?: boolean;
+} & ComponentProps<"a">;
 
 export function Link(props: LinkProps) {
-  const href = useHref(props.href ?? "");
+  const href = useHref(props.href ?? "", props.ignoreLocale);
 
   if (isExternalLink(props.href ?? "")) {
     return (

--- a/website/app/components/Locale.tsx
+++ b/website/app/components/Locale.tsx
@@ -46,6 +46,7 @@ export function Locale() {
                 <MenuItem key={locale}>
                   <Link
                     href={`/${locale}`}
+                    ignoreLocale
                     className="flex w-full rounded-lg hover:bg-black/5 hover:dark:bg-white/5 px-3 py-1.5 text-sm"
                   >
                     {iso639LanguageCodes[locale]}

--- a/website/app/context.ts
+++ b/website/app/context.ts
@@ -116,9 +116,9 @@ export function useSidebar(): SidebarGroup[] {
 }
 
 // Resolves a path to a full URL.
-export function useHref(path: string): string {
+export function useHref(path: string, ignoreLocale: boolean = false): string {
   const ctx = usePageContext();
-  return getHref(ctx, path);
+  return getHref(ctx, path, ignoreLocale);
 }
 
 // Returns the active tab for the current page.

--- a/website/app/utils.ts
+++ b/website/app/utils.ts
@@ -175,8 +175,8 @@ export function getLocale(ctx: Context) {
 // If the path is external, it is returned as is.
 // If we're in preview mode, the path is prefixed with `/preview`.
 // Otherwise applies the owner, repository, ref and locale to the path.
-export function getHref(ctx: Context, path: string) {
-  const locale = getLocale(ctx);
+export function getHref(ctx: Context, path: string, ignoreLocale: boolean = false) {
+  const locale = ignoreLocale ? undefined : getLocale(ctx);
 
   // Ensures a path, e.g. foo/bar becomes /foo/bar
   let normalizedPath = ensureLeadingSlash(path);


### PR DESCRIPTION
Fixes https://github.com/invertase/docs.page/issues/370

Adds a new `ignoreLocale` parameter to `getHref` which is used by the `Locale` component.