### PR TITLE
fix: Prevent non-external links from opening in new tab

### DIFF
--- a/website/src/components/Anchors.tsx
+++ b/website/src/components/Anchors.tsx
@@ -31,7 +31,7 @@ export function Anchors() {
           <li key={anchor.href}>
             <a
               rel="noopener noreferrer"
-              target={isExternalLink(anchor.href) ? "_blank" : undefined}
+              target={isExternalLink(anchor.href) ? "_blank" : ""}
               href={anchor.href}
               className="group flex items-center gap-2"
             >

--- a/website/src/components/mdx/Card.tsx
+++ b/website/src/components/mdx/Card.tsx
@@ -54,7 +54,7 @@ export function Card({ href, icon, title, children, ...props }: CardProps) {
       className="group block no-underline"
       href={_href}
       rel="noopener noreferrer"
-      target={isExternalLink(_href) ? "_blank" : undefined}
+      target={isExternalLink(_href) ? "_blank" : ""}
     >
       {card}
     </a>


### PR DESCRIPTION
Setting target to undefined still causes the browser to treat it as a value, often opening the link in a new tab. This fix ensures target="_blank" is only set when the link is external, preventing unexpected navigation for internal links.