### PR TITLE
Fix preview footer crash and improve docs UI accessibility

### DIFF
--- a/app/src/components/action-menu.tsx
+++ b/app/src/components/action-menu.tsx
@@ -41,13 +41,18 @@ export function ActionMenu() {
 
   return (
     <ButtonGroup>
-      <Button variant="outline" className="gap-2" onClick={handleCopy}>
+      <Button
+        variant="outline"
+        className="gap-2"
+        aria-label="Copy page"
+        onClick={handleCopy}
+      >
         {copied ? <RiCheckLine /> : <RiFileCopyLine />}
         <span className="hidden md:inline">Copy page</span>
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="outline" className="pl-2!">
+          <Button variant="outline" className="pl-2!" aria-label="More page actions">
             <RiArrowDownSLine />
           </Button>
         </DropdownMenuTrigger>

--- a/app/src/components/action-menu.tsx
+++ b/app/src/components/action-menu.tsx
@@ -52,7 +52,11 @@ export function ActionMenu() {
       </Button>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="outline" className="pl-2!" aria-label="More page actions">
+          <Button
+            variant="outline"
+            className="pl-2!"
+            aria-label="More page actions"
+          >
             <RiArrowDownSLine />
           </Button>
         </DropdownMenuTrigger>

--- a/app/src/components/footer.tsx
+++ b/app/src/components/footer.tsx
@@ -14,6 +14,18 @@ const icons: Record<string, string> = {
   discord: "fa-brands fa-discord",
 };
 
+const networkLabels: Record<string, string> = {
+  website: "Website",
+  x: "X",
+  youtube: "YouTube",
+  facebook: "Facebook",
+  instagram: "Instagram",
+  linkedin: "LinkedIn",
+  github: "GitHub",
+  slack: "Slack",
+  discord: "Discord",
+};
+
 const links: Record<string, (value: string) => string> = {
   website: (value) => value,
   x: (value) => `https://twitter.com/${value}`,
@@ -68,6 +80,7 @@ export function Footer() {
               href={links[name](url)}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label={networkLabels[name] ?? name}
             >
               <i className={cn(icons[name], "text-[16px]")} />
             </a>

--- a/app/src/components/footer.tsx
+++ b/app/src/components/footer.tsx
@@ -40,7 +40,9 @@ export function Footer() {
 
   // Sorting here ensures that the socials are always displayed in the same order,
   // on client and server side.
-  const sorted = socials.sort(([a], [b]) => a.localeCompare(b));
+  const sorted = socials
+    .filter(([name, url]) => Boolean(url) && links[name])
+    .sort(([a], [b]) => a.localeCompare(b));
 
   return (
     <footer className="py-12 border-t flex text-muted-foreground">

--- a/app/src/components/header.tsx
+++ b/app/src/components/header.tsx
@@ -77,7 +77,7 @@ function Logo() {
   const hasDarkLogo = Boolean(logo?.dark);
   const lightLogoSrc = hasLightLogo ? getAssetSrc(bundle, logo!.light!) : "";
   const darkLogoSrc = hasDarkLogo ? getAssetSrc(bundle, logo!.dark!) : "";
-  const logoAlt = showName && name ? "" : (name || "Home");
+  const logoAlt = showName && name ? "" : name || "Home";
 
   return (
     <div className="flex min-w-0 flex-1 items-center justify-start gap-3">

--- a/app/src/components/header.tsx
+++ b/app/src/components/header.tsx
@@ -77,6 +77,7 @@ function Logo() {
   const hasDarkLogo = Boolean(logo?.dark);
   const lightLogoSrc = hasLightLogo ? getAssetSrc(bundle, logo!.light!) : "";
   const darkLogoSrc = hasDarkLogo ? getAssetSrc(bundle, logo!.dark!) : "";
+  const logoAlt = showName && name ? "" : (name || "Home");
 
   return (
     <div className="flex min-w-0 flex-1 items-center justify-start gap-3">
@@ -85,14 +86,14 @@ function Logo() {
           <img
             className={`relative block h-6 w-auto shrink-0 ${hasDarkLogo ? "dark:hidden" : ""}`}
             src={lightLogoSrc}
-            alt="Light logo"
+            alt={logoAlt}
           />
         )}
         {hasDarkLogo && (
           <img
             className={`relative h-6 w-auto shrink-0 ${hasLightLogo ? "hidden dark:block" : "block"}`}
             src={darkLogoSrc}
-            alt="Dark logo"
+            alt={logoAlt}
           />
         )}
         {showName && !!name && (
@@ -168,7 +169,7 @@ function GitHubLink() {
     <Button
       variant="ghost"
       size="lg"
-      aria-label="Toggle theme"
+      aria-label="View repository on GitHub"
       className="gap-2"
       asChild
     >

--- a/app/src/components/mdx/card.tsx
+++ b/app/src/components/mdx/card.tsx
@@ -21,7 +21,7 @@ export function Card({ title, icon, href, children }: CardProps) {
   const container = (children: React.ReactNode) => {
     if (href) {
       return (
-        <Link href={href} className="block">
+        <Link href={href} className="block h-full">
           {children}
         </Link>
       );
@@ -32,7 +32,7 @@ export function Card({ title, icon, href, children }: CardProps) {
 
   return container(
     <CardPrimitive
-      className={cn("group", href && "border hover:border-primary")}
+      className={cn("group h-full", href && "border hover:border-primary")}
     >
       {title || icon || href ? (
         <CardHeader>
@@ -53,7 +53,7 @@ export function Card({ title, icon, href, children }: CardProps) {
       ) : null}
       <CardContent
         className={cn(
-          "space-y-4 text-foreground/90",
+          "flex-1 space-y-4 text-foreground/90",
           href && "group-hover:text-primary",
         )}
       >
@@ -78,7 +78,7 @@ export function CardGroup({ cols = 2, children }: CardGroupProps) {
   return (
     <div
       className={cn(
-        "grid grid-cols-1 gap-4",
+        "grid grid-cols-1 items-stretch gap-4",
         smGridCols[cols] ?? "sm:grid-cols-2",
       )}
     >

--- a/app/src/components/previous-next.tsx
+++ b/app/src/components/previous-next.tsx
@@ -119,7 +119,14 @@ export function PreviousNext() {
 function Anchor(props: AnchorSource & { type: "previous" | "next" }) {
   return (
     <Button variant="secondary" asChild>
-      <Link href={props.href}>
+      <Link
+        href={props.href}
+        aria-label={
+          props.type === "previous"
+            ? `Previous: ${props.title}`
+            : `Next: ${props.title}`
+        }
+      >
         {props.type === "previous" ? <RiArrowLeftLine size={16} /> : ""}
         <span>{props.title}</span>
         {props.type === "next" ? <RiArrowRightLine size={16} /> : ""}

--- a/app/src/server/config/models/social.ts
+++ b/app/src/server/config/models/social.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 
 export default z
   .object({
-    preview: z.string().optional().catch(undefined),
     website: z.string().optional().catch(undefined),
     x: z.string().optional().catch(undefined),
     youtube: z.string().optional().catch(undefined),
@@ -13,15 +12,4 @@ export default z
     slack: z.string().optional().catch(undefined),
     discord: z.string().optional().catch(undefined),
   })
-  .catch({
-    preview: undefined,
-    website: undefined,
-    x: undefined,
-    youtube: undefined,
-    facebook: undefined,
-    instagram: undefined,
-    linkedin: undefined,
-    github: undefined,
-    slack: undefined,
-    discord: undefined,
-  });
+  .catch({});


### PR DESCRIPTION
## Summary

### Preview crash fix
- Skip empty and unknown `social` entries in the footer before building icon links
- Remove the stray `preview` key from the social schema and default missing config to `{}`

Fixes a client-side crash in `docs preview` when `docs.json` has no `social` block. The schema fallback was emitting undefined keys (including `preview`), and the footer called `links[name](url)` for every entry.

### Accessibility and layout
While reviewing the docs site, several icon-only controls had missing or incorrect accessible names. These fixes ship alongside the footer work because the footer is already in scope and the other changes are small, related UI polish:

- **Footer social links** — add `aria-label` per network (GitHub, X, etc.) so icon-only links announce a readable name
- **Header GitHub link** — fix copy-paste bug where `aria-label` was `"Toggle theme"` instead of `"View repository on GitHub"`
- **Header logo** — use site name or `"Home"` for logo alt text instead of `"Light logo"` / `"Dark logo"`
- **Action menu** — label the Copy button and chevron menu trigger for mobile (text hidden below `md`)
- **Previous/Next navigation** — include direction in `aria-label` (`Previous: …` / `Next: …`)
- **Related cards** — stretch MDX cards to equal height within grid rows so short descriptions no longer leave mismatched card heights

## Test plan
- [ ] Run `docs preview` against a project with no `social` block in `docs.json`
- [ ] Confirm the preview page renders instead of showing a client-side exception
- [ ] Confirm footer social icons still render when valid `social` entries are configured
- [ ] With VoiceOver or axe, confirm header GitHub link, footer social links, Copy menu, and Previous/Next announce readable names
- [ ] On a page with Related cards (e.g. Agent-ready docs), confirm cards in the same row share equal height