### PR TITLE
docs: update README for docs-as-code positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ https://docs.page/{owner}/{repo}
 
 ## Features
 
-- **[Agent-ready](https://use.docs.page/ai-agents/overview):** Let users' AI agents query your documentation. Built-in MCP servers and llms.txt allow LLMs to ingest your product context instantly.
+- **[Agent-ready](https://use.docs.page/ai-agents/overview):** MCP server and auto-generated `llms.txt` on every public site. Add optional [agent skills](https://use.docs.page/ai-agents/agent-skills) and enable [Ask AI](https://use.docs.page/ai-agents/ask-ai) (beta) so LLMs and readers can query your docs without a separate mirror.
 - **Git publishing:** Deploy updates directly from your public GitHub repository. Eliminate build pipelines, hosting configuration, or infrastructure maintenance.
-- **[Intelligent search](https://use.docs.page/features/search):** Index content automatically and provide embedded AI chat. Locate information instantly without third-party tracking scripts or external setup.
+- **[Intelligent search](https://use.docs.page/features/search):** Built-in full-text index (Cmd+K) plus embedded AI chat. Locate information instantly without third-party tracking scripts or external setup.
 - **[Markdown components](https://use.docs.page/components):** Add interactive components to your docs with MDX for richer experiences than standard Markdown.
 - **[Branches & versions](https://use.docs.page/features/branch-preview):** Serve any Git branch, tag, or release as a distinct documentation site. Organise versions and live staging previews on the fly.
 - **[Modern interface](https://use.docs.page/features/theme):** Style your docs site using shadcn/ui design standards. Customize components easily to match your brand identity.

--- a/README.md
+++ b/README.md
@@ -1,57 +1,55 @@
 <p align="center">
   <img src="https://static.invertase.io/assets/docs.page/docs-page-logo-v2.png" alt="docs.page" height="120" /> <br /><br />
-  <span>Instant Open Source docs with zero configuration.</span>
+  <span>Free and open-source</span><br />
+  <strong>Docs for humans + agents</strong><br /><br />
+  <span>Instantly serve markdown from any GitHub branch as modern, agent-ready docs, with AI chat, MCP, and llms.txt.</span>
 </p>
 
 <p align="center">
   <a href="https://docs.page"><img src="https://img.shields.io/badge/powered%20by-docs.page-34C4AC.svg?style=flat-square" alt="docs.page" /></a>
-   <a href="https://invertase.link/discord">
-   <img src="https://img.shields.io/discord/295953187817521152.svg?style=flat-square&colorA=7289da&label=Chat%20on%20Discord" alt="Chat on Discord">
- </a>
+  <a href="https://invertase.link/discord">
+    <img src="https://img.shields.io/discord/295953187817521152.svg?style=flat-square&colorA=7289da&label=Chat%20on%20Discord" alt="Chat on Discord">
+  </a>
 </p>
 
 <p align="center">
-  <a href="https://docs.page">Homepage</a> &bull; <a href="https://use.docs.page">Documentation</a>
+  <a href="https://docs.page">Homepage</a> &bull;
+  <a href="https://use.docs.page">Documentation</a> &bull;
+  <a href="https://use.docs.page/quickstart">Quickstart</a> &bull;
+  <a href="https://github.com/invertase/docs.page/blob/ai/CONTRIBUTING.md">Contribute</a> &bull;
+  <a href="https://github.com/invertase/docs.page/discussions">Discussions</a>
 </p>
 
-## About
+## Quick start
 
-docs.page is a free Open Source project, allowing you to create instant, fast, beautiful documentation with zero configuration.
+```bash
+npx @docs.page/cli init
+```
 
-Documentation is an important aspect for many projects, however creating a custom documentation website
-for each project is time consuming. Many common solutions to problems have to be duplicated, along with
-dealing with overheads such as website maintenance & hosting.
+Push `docs.json` and `docs/` to a **public** GitHub repository. Your site is live at:
 
-Solutions such as [Jekyll](https://jekyllrb.com/docs/github-pages/), [Docusaurus](https://docusaurus.io/),
-[docsify](https://docsify.js.org/#/) and many others are great projects, however still require custom setup for each project.
+```
+https://docs.page/{owner}/{repo}
+```
 
-docs.page is designed to deliver instant documentation websites, with the content sourced directly from any public
-GitHub repository. Features include:
+## Features
 
-- [Configurable](https://use.docs.page/configuration): Add your own logo, theme, analytics, navigation and more with a simple config file.
-- [Previewing](https://use.docs.page/previews): View the documentation of any branch, pull request or specific commit, and a new Local Preview Mode.
-- [GitHub Bot](https://use.docs.page/github-bot): Install our [GitHub bot](https://github.com/apps/docs-page) to automatically get a URL to pull request documentation previews.
-- [Components](https://use.docs.page/components/accordion): Powered by [MDX](https://github.com/mdx-js/mdx), use React components such as Tabs (useful for projects with multiple languages) directly in your docs.
-- [Search](https://use.docs.page/search): Easily add full search support powered by [DocSearch](https://docsearch.algolia.com/).
-- [Custom Domains](https://use.docs.page/custom-domains): Serve your documentation using your own domain.
-
-Other useful features include:
-
-- Global variable injection (for managing common variables across the project).
-- Displaying assets using GitHub.
-- Dark/Light mode.
-- Responsive.
-- Code block highlighting and content copying.
-- Page redirects.
-- Per-page metadata support via Frontmatter.
+- **[Agent-ready](https://use.docs.page/ai-agents/overview):** Let users' AI agents query your documentation. Built-in MCP servers and llms.txt allow LLMs to ingest your product context instantly.
+- **Git publishing:** Deploy updates directly from your public GitHub repository. Eliminate build pipelines, hosting configuration, or infrastructure maintenance.
+- **[Intelligent search](https://use.docs.page/features/search):** Index content automatically and provide embedded AI chat. Locate information instantly without third-party tracking scripts or external setup.
+- **[Markdown components](https://use.docs.page/components):** Add interactive components to your docs with MDX for richer experiences than standard Markdown.
+- **[Branches & versions](https://use.docs.page/features/branch-preview):** Serve any Git branch, tag, or release as a distinct documentation site. Organise versions and live staging previews on the fly.
+- **[Modern interface](https://use.docs.page/features/theme):** Style your docs site using shadcn/ui design standards. Customize components easily to match your brand identity.
 
 ## Should I use docs.page?
 
-docs.page is a simple way to generate a documentation with zero effort. It generally works for documentation websites with a lot of Markdown based content. If you require features which are more specific to your own project a custom solution might work better.
+**Bring your docs into the agentic age.** Use docs.page when you want markdown from a public GitHub repository served as a modern documentation site for human readers and AI agents, without build pipelines, hosting setup, or a docs SaaS.
+
+Not sure how docs.page compares to Docusaurus, Mintlify, or GitHub Pages? See [comparisons](https://use.docs.page/comparisons).
 
 ## License
 
-- See [LICENSE](/LICENSE)
+See [LICENSE](/LICENSE).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ https://docs.page/{owner}/{repo}
 ## Features
 
 - **[Agent-ready](https://use.docs.page/ai-agents/overview):** MCP server and auto-generated `llms.txt` on every public site. Add optional [agent skills](https://use.docs.page/ai-agents/agent-skills) and enable [Ask AI](https://use.docs.page/ai-agents/ask-ai) (beta) so LLMs and readers can query your docs without a separate mirror.
-- **Git publishing:** Deploy updates directly from your public GitHub repository. Eliminate build pipelines, hosting configuration, or infrastructure maintenance.
+- **[Git publishing](https://use.docs.page/features/public-github-hosting):** Deploy updates directly from your public GitHub repository. Eliminate build pipelines, hosting configuration, or infrastructure maintenance.
 - **[Intelligent search](https://use.docs.page/features/search):** Built-in full-text index (Cmd+K) plus embedded AI chat. Locate information instantly without third-party tracking scripts or external setup.
 - **[Markdown components](https://use.docs.page/components):** Add interactive components to your docs with MDX for richer experiences than standard Markdown.
 - **[Branches & versions](https://use.docs.page/features/branch-preview):** Serve any Git branch, tag, or release as a distinct documentation site. Organise versions and live staging previews on the fly.


### PR DESCRIPTION
## Summary

- Refreshes the repository README with the new tagline and docs-as-code positioning
- Adds a **Quick start** section (`npx @docs.page/cli init`) above the fold
- Updates feature links to match the docs rewrite IA (quickstart, features, ai-agents, reference)
- Strengthens **Should I use docs.page?** with positive fit guidance and a comparisons link

## Scope

README only — no other hygiene or docs content changes in this PR.

## Note

Several doc links target paths from the docs rewrite branch (`integrate/docs-rewrite` / #478). They will 404 on `use.docs.page` until that lands on `main`.

## Test plan

- [ ] Review README rendering on GitHub
- [ ] Confirm quickstart command and links read correctly

Made with [Cursor](https://cursor.com)