### PR TITLE
chore: add contributor governance , agent md, skills folder, and issue/pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -1,0 +1,106 @@
+name: Bug report
+description: Something is broken on docs.page, in the CLI, or in local preview
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Search [existing issues](https://github.com/invertase/docs.page/issues?q=is%3Aissue+is%3Aopen) first.
+
+        **Not sure where to start?** Use [Discussions](https://github.com/invertase/docs.page/discussions) for questions and ideas.
+
+        If this is about **your own published docs site**, include the docs.page URL and the GitHub repo below.
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where does this happen?
+      options:
+        - Hosted docs site (a URL on docs.page)
+        - CLI local preview (`docs.page preview`)
+        - Both hosted and preview
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: docs_url
+    attributes:
+      label: docs.page URL
+      description: The page where you see the problem, if applicable.
+      placeholder: https://invertase.docs.page/configuration
+
+  - type: input
+    id: repo
+    attributes:
+      label: GitHub repository
+      description: The repo whose docs you are viewing, if applicable.
+      placeholder: invertase/docs.page
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: What you did, what you expected, and what actually happened.
+      placeholder: |
+        When I …
+        I expected …
+        Instead …
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps, commands, or URLs. For CLI issues, include the exact command.
+      placeholder: |
+        1. Run `docs.page preview`
+        2. Open http://localhost:…/page
+        3. See …
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Rendering / navigation / sidebar
+        - Search
+        - Preview mode (hosted PR/branch previews)
+        - CLI (`@docs.page/cli`)
+        - `docs.json` / configuration
+        - MCP / agent features
+        - Product docs (use.docs.page content)
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: CLI version or browser
+      description: e.g. `@docs.page/cli 2.0.0-next.1`, Chrome 124, Safari 17
+      placeholder: "@docs.page/cli …"
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Console errors, CLI output, or stack traces.
+      render: shell
+
+  - type: upload
+    id: screenshots
+    attributes:
+      label: Screenshots or recordings
+      description: If applicable, upload images to help explain the problem.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Preview URL, commit SHA, or anything else that helps reproduce the issue.

--- a/.github/ISSUE_TEMPLATE/2-feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.yml
@@ -1,0 +1,67 @@
+name: Feature request
+description: Suggest an improvement to docs.page, the CLI, or the docs experience
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem you want solved. For open-ended questions or roadmap chat, use [Discussions](https://github.com/invertase/docs.page/discussions) instead.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What problem does this solve? Who benefits (site owners, readers, maintainers)?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you like this to work? Mockups, examples, or links to other docs sites are welcome.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches, workarounds, or tools you considered.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Hosted platform (docs.page)
+        - CLI (`@docs.page/cli`)
+        - `docs.json` / configuration
+        - Search / analytics
+        - Preview mode
+        - MCP / agent / AI features
+        - Product documentation / DX
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: How important is this to you?
+      options:
+        - Nice to have
+        - Would improve my workflow
+        - Blocking — I can't use docs.page the way I need
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to open a PR for this (with maintainer guidance)
+        - label: I can help test a prototype

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions, ideas & roadmap
+    url: https://github.com/invertase/docs.page/discussions
+    about: General questions, feedback, and roadmap — start here when you're not sure
+  - name: Configuration help
+    url: https://use.docs.page/configuration
+    about: docs.json options, navigation, themes — start here for setup questions
+  - name: Discord
+    url: https://invertase.link/discord
+    about: Chat with the community

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+Fixes #
+
+## Summary
+
+<!-- What changed and why? -->
+
+## Scope
+
+- [ ] `app/` (hosted site, MCP, Ask AI)
+- [ ] `packages/cli/`
+- [ ] `packages/mdx-bundler/`
+- [ ] `docs/` (product documentation)
+- [ ] Repo / CI / other
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactor / chore
+
+## Test plan
+
+<!-- Commands run, URLs tested, screenshots. For UI changes, include before/after if helpful. -->
+
+- [ ] `bun run check` passes locally
+- [ ] Tested locally (`bun dev`, CLI command, or other relevant command)
+- [ ] Updated `docs/` (if user-facing)
+- [ ] Verified on a docs.page URL or local preview (if rendering/routing changed)
+
+## Notes for reviewers
+
+<!-- Breaking changes, migration steps, follow-ups, or areas that need extra attention. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,6 @@ docs.json               Site navigation for this repo's docs
 skills/                 Agent skills (SKILL.md per skill)
 ```
 
-Legacy paths (`api/`, `website/`, `og/`) are not part of the current architecture.
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# docs.page — agent guidance
+
+This file orients coding agents working in the docs.page monorepo. For human
+contributors, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## Project overview
+
+docs.page serves markdown documentation from public GitHub repositories as modern,
+agent-ready sites (MCP, `llms.txt`, optional Ask AI). The active codebase is a
+Bun workspace centered on a Next.js app and shared packages.
+
+## Monorepo layout
+
+```
+app/                    Next.js app — rendering, API routes, MCP, agent panel
+packages/cli/           @docs.page/cli — init, check, preview
+packages/mdx-bundler/   Shared markdown → doc IR pipeline
+docs/                   Product documentation (MDX)
+docs.json               Site navigation for this repo's docs
+skills/                 Agent skills (SKILL.md per skill)
+```
+
+Legacy paths (`api/`, `website/`, `og/`) are not part of the current architecture.
+
+## Commands
+
+| Task | Command |
+| --- | --- |
+| Install | `bun install` (repo root) |
+| Dev server | `bun dev` or `cd app && bun dev` |
+| Format + lint | `bun run check` (Biome, repo root) |
+| CLI dev | `cd packages/cli && bun run dev` |
+| CLI typecheck | `cd packages/cli && bun run typecheck` |
+
+## Conventions
+
+- **Runtime** — Bun for installs and scripts; Next.js App Router in `app/`.
+- **Lint/format** — Biome (`biome.json`). Run `bun run check` before finishing.
+- **UI** — shadcn/ui components live in `app/src/components/ui/`. Use existing primitives before adding dependencies.
+- **Next.js** — Read `app/AGENTS.md` and `node_modules/next/dist/docs/` for Next.js 16 APIs (breaking vs training data).
+- **Shared markdown pipeline** — Changes to doc rendering belong in `packages/mdx-bundler/` when they affect both app and CLI preview.
+- **Scope** — Minimal diffs; match existing patterns; update `docs/` for user-visible behavior.
+
+## Environment
+
+Local app development against live GitHub content requires `GITHUB_PAT` in
+`app/.env.local`. GitHub App credentials are only needed for webhook work.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for setup.
+
+Do not commit secrets, `.env`, or generated artifacts (`.next/`, `dist/`).
+
+## Pull requests
+
+- Link issues when applicable (`Fixes #123`).
+- Follow [CONTRIBUTING.md](./CONTRIBUTING.md) for workflow and [.github/pull_request_template.md](./.github/pull_request_template.md) when opening a PR.
+- Ensure Biome passes (`bun run check`).
+- Prefer focused PRs with a clear description.
+
+## Skills
+
+Repo-wide skills live under [`skills/`](./skills/). Load a skill's `SKILL.md` when one exists for your task.
+
+## Safety
+
+- Do not disable security checks (webhook verification, sanitization, rate limits) without explicit maintainer approval.
+- Treat user-supplied markdown and repository content as untrusted input.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,24 +1,64 @@
 # Contributing
 
-This repository uses [Bun](https://bun.sh/) for workspace and dependency management. To get started, run the following commands:
+Thank you for helping improve docs.page. This guide covers how to contribute to this repository.
+
+Using a coding agent? Jump to [Contributing with an agent](#contributing-with-an-agent).
+
+## Get involved
+
+- **[Discussions](https://github.com/invertase/docs.page/discussions)** — questions, ideas, roadmap, and general feedback. Start here when you're not sure.
+- **[Issues](https://github.com/invertase/docs.page/issues/new/choose)** — bugs and feature requests. Use the [issue templates](.github/ISSUE_TEMPLATE/); one problem per issue.
+- **[Pull requests](https://github.com/invertase/docs.page/compare)** — code, docs, or any change to the repo. Use the [PR template](.github/pull_request_template.md).
+
+Chat with the community on [Discord](https://invertase.link/discord).
+
+## Development
 
 ```bash
+git clone https://github.com/invertase/docs.page.git
+cd docs.page
 bun install
+bun dev
 ```
 
-The repository is structured as follows:
+The site runs at [http://localhost:3000](http://localhost:3000).
 
-- `app`: The Next.js application running the docs.page website.
-- `packages/cli`: A CLI for running various commands and scripts for initialization, checking etc. Used locally and on CI environments.
+| Path | Purpose |
+| --- | --- |
+| `app/` | Next.js app — rendering, MCP, Ask AI, preview |
+| `packages/cli/` | `@docs.page/cli` — init, check, preview |
+| `packages/mdx-bundler/` | Shared markdown pipeline |
+| `docs/` | Product documentation (MDX) |
 
-## Running docs.page
+> **GitHub tokens:** Not required for most work. Set `GITHUB_PAT` in `app/.env.local` only if you need the app to fetch live GitHub content.
 
-Generally, you'll want to interface with the website and api. To run these concurrently, you can use the following command:
+Run `bun run check` before opening a PR. Update `docs/` when behavior is user-facing.
 
-```bash
-cd app && bun dev
+## Contributing with an agent
+
+Copy this into a new agent session, then describe your task:
+
+```
+You are contributing to docs.page (github.com/invertase/docs.page).
+
+Read before making changes:
+1. CONTRIBUTING.md — workflow (this file)
+2. AGENTS.md — repo layout, commands, and code conventions
+3. .github/pull_request_template.md — follow when opening a PR
+4. .github/ISSUE_TEMPLATE/ — use when filing a bug or feature request
+
+Task: [e.g. "fix #123", "add docs for preview command"]
+
+Deliver:
+- Focused diff; do not edit legacy folders (api/, website/, og/)
+- Run `bun run check` before finishing
+- Update docs/ if behavior is user-facing
+- Fill out the PR template; link related issues (Fixes #…)
+- Ideas or large features → suggest a Discussion first, not a drive-by PR
 ```
 
-This will start the website on `http://localhost:3000`. 
+Code-level detail lives in [AGENTS.md](AGENTS.md).
 
-> The API requires a `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` to be set in your environment. These are used to authenticate with the GitHub API. You can create a GitHub App in your GitHub account settings.
+## License
+
+By contributing, you agree your contributions are licensed under [Apache-2.0](LICENSE).

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,5 @@
+# Agent skills
+
+Repository-wide agent skills live here — one folder per skill with a `SKILL.md` entry point.
+
+To add a skill: create `skills/{skill-name}/SKILL.md` and mention it in [AGENTS.md](../AGENTS.md) if it should be discoverable by default.


### PR DESCRIPTION
## Summary

Contributor governance and agent tooling for docs.page v2.

**Base:** `ai` · **For review — do not merge without approval**

## What's in this PR

| File | Purpose |
| --- | --- |
| `CONTRIBUTING.md` | v2 monorepo workflow — Discussions / Issues / PRs, `bun dev`, agent prompt |
| `AGENTS.md` | Coding agent guide — layout, commands, conventions |
| `.github/pull_request_template.md` | PR template |
| `.github/ISSUE_TEMPLATE/*.yml` | Bug + feature forms, chooser config |
| `skills/` | Agent skills directory scaffold (README + placeholders) |

## Explicitly not in this PR

- `CODE_OF_CONDUCT.md`, `README.md`, docs site changes
- `CHANGELOG.md` / `RELEASES.md`, `SECURITY.md`, `.gitignore`
- Actual skill implementations under `skills/*/` (only scaffold + README)
- Gemini Code Assist config (`.gemini/`) — removed; requires a paid plan

## Reviewer notes

- Issue/PR templates activate on **default branch** (`main`) after cutover
- `.github/workflows/pull_request.yaml` is CI only — unchanged

## Test plan

- [ ] Read `CONTRIBUTING.md` + `AGENTS.md` — consistent paths and commands
- [ ] Skim issue/PR templates