### PR TITLE
fix: prevent table overflow inside Steps component

### DIFF
--- a/website/src/components/mdx/Table.tsx
+++ b/website/src/components/mdx/Table.tsx
@@ -4,7 +4,7 @@ type TableProps = ComponentProps<"table">;
 
 export function Table(props: TableProps) {
   return (
-    <div className="[& img]:inline">
+    <div className="overflow-x-auto [&_img]:inline">
       <table {...props} className="table" />
     </div>
   );


### PR DESCRIPTION
## Summary

Fixes #484 — markdown tables inside a `<Step>` could break the page layout.

Tables parse correctly into proper `<table>` elements, but the `Table` component had no horizontal-overflow containment. A wide table (e.g. a row with a long URL) escaped its column, which is most visible inside the narrow `<Step>` content column and pushes the whole page sideways on narrow/mobile viewports.

## Changes

- Wrap the table in an `overflow-x-auto` container so wide tables scroll within their own box instead of overflowing the layout.
- Fix the invalid `[& img]:inline` arbitrary variant — the space made it invalid Tailwind that generated no CSS; changed to `[&_img]:inline`.

```diff
- <div className="[& img]:inline">
+ <div className="overflow-x-auto [&_img]:inline">
```

## Testing

Local preview (`/preview`) with a table inside a `<Step>` containing a long URL cell: at a narrow column width the table now scrolls within its container rather than overflowing the page.