### PR TITLE
fix: bare anchor fragments do not need '/' prepend

### DIFF
--- a/app/src/lib/docs-nav.test.ts
+++ b/app/src/lib/docs-nav.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from "bun:test";
+import { resolveInternalDocHref } from "./docs-nav";
+import type { ResolvedDocsRoute } from "./docs-routing";
+
+function createRoute(
+  overrides: Partial<ResolvedDocsRoute> = {},
+): ResolvedDocsRoute {
+  return {
+    owner: "invertase",
+    repository: "docs.page",
+    ref: null,
+    docPath: "writing-content",
+    requestMode: "canonical",
+    vanity: false,
+    customDomain: false,
+    canonicalPathname: "/invertase/docs.page/writing-content",
+    publicPathname: "/invertase/docs.page/writing-content",
+    canonicalUrl: null,
+    ...overrides,
+  };
+}
+
+describe("resolveInternalDocHref", () => {
+  test("returns bare hash fragments unchanged", () => {
+    const route = createRoute();
+
+    expect(resolveInternalDocHref(route, "#section")).toBe("#section");
+    expect(resolveInternalDocHref(route, "#my-heading")).toBe("#my-heading");
+  });
+
+  test("prefixes internal page paths", () => {
+    const route = createRoute();
+
+    expect(resolveInternalDocHref(route, "/writing-content")).toBe(
+      "/invertase/docs.page/writing-content",
+    );
+    expect(resolveInternalDocHref(route, "/other-page")).toBe(
+      "/invertase/docs.page/other-page",
+    );
+  });
+
+  test("prefixes internal page paths with hash fragments", () => {
+    const route = createRoute();
+
+    expect(resolveInternalDocHref(route, "/other-page#section")).toBe(
+      "/invertase/docs.page/other-page#section",
+    );
+  });
+
+  test("returns external links unchanged", () => {
+    const route = createRoute();
+
+    expect(resolveInternalDocHref(route, "https://example.com")).toBe(
+      "https://example.com",
+    );
+    expect(
+      resolveInternalDocHref(route, "https://example.com/page#section"),
+    ).toBe("https://example.com/page#section");
+  });
+
+  test("returns bare hash fragments unchanged in preview mode", () => {
+    const route = createRoute({ requestMode: "preview" });
+
+    expect(resolveInternalDocHref(route, "#section")).toBe("#section");
+  });
+
+  test("prefixes preview paths but not bare hash fragments", () => {
+    const route = createRoute({ requestMode: "preview" });
+
+    expect(resolveInternalDocHref(route, "/writing-content")).toBe(
+      "/preview/writing-content",
+    );
+  });
+
+  test("includes ref in prefixed paths", () => {
+    const route = createRoute({ ref: "main" });
+
+    expect(resolveInternalDocHref(route, "/writing-content")).toBe(
+      "/invertase/docs.page~main/writing-content",
+    );
+  });
+});

--- a/app/src/lib/docs-nav.ts
+++ b/app/src/lib/docs-nav.ts
@@ -49,6 +49,13 @@ export function resolveInternalDocHref(
   href: string,
   locales: string[] = [],
 ): string {
+  const trimmed = href.trim();
+
+  // Hash-only links are same-page anchors; do not prefix with site path.
+  if (trimmed.startsWith("#")) {
+    return trimmed;
+  }
+
   const docPath = resolveLocalizedDocPath(route.docPath, href, locales);
   if (isExternalLink(docPath)) {
     return docPath;

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+coverageSkipTestFiles = true
+coverageReporter = ["text"]

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "scripts": {
     "dev": "cd app && bun dev",
     "check": "bunx @biomejs/biome check --write .",
+    "test": "bun test --coverage",
     "test:mdx": "bun ./test/run-all.ts"
   },
   "dependencies": {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,14 +1,13 @@
 #!/usr/bin/env node
 
 import { Command, Option } from "commander";
-
+import { version } from "../package.json";
 import { registerAgentCommand } from "./commands/agent";
 import { registerCheckCommand } from "./commands/check";
 import { registerInitCommand } from "./commands/init";
 import { registerPreviewCommand } from "./commands/preview";
 import { DEFAULT_API_BASE_URL } from "./lib/api";
 import { handleCliError } from "./lib/errors";
-import { version } from "../package.json";
 
 const program = new Command();
 


### PR DESCRIPTION
also added minimal test target with coverage report, and tests for the fix (`app/src/lib/docs-nav.test.ts` at the top is the added test blop)

```
mike@krakatoa:~/work/invertase/docs.page (fix-bare-fragment-anchors *) % npm test

> test
> bun test --coverage

bun test v1.3.14 (0d9b296a)

app/src/lib/docs-nav.test.ts:
✓ resolveInternalDocHref > returns bare hash fragments unchanged [1.36ms]
✓ resolveInternalDocHref > prefixes internal page paths [2.76ms]
✓ resolveInternalDocHref > prefixes internal page paths with hash fragments [0.02ms]
✓ resolveInternalDocHref > returns external links unchanged [0.01ms]
✓ resolveInternalDocHref > returns bare hash fragments unchanged in preview mode [0.01ms]
✓ resolveInternalDocHref > prefixes preview paths but not bare hash fragments [0.01ms]
✓ resolveInternalDocHref > includes ref in prefixed paths [0.01ms]

app/src/server/github/ref-validation.test.ts:
✓ isUnresolvedNumericRef > flags numeric refs that fell through PR resolution [0.04ms]
✓ isUnresolvedNumericRef > allows numeric refs once they resolve to PR metadata
✓ isUnresolvedNumericRef > allows non-numeric branch names

packages/cli/src/lib/docs-config.test.ts:
✓ hasNonLatin1 > detects characters browser btoa cannot encode [0.15ms]
✓ usesAutoOgImage > uses auto social image when no image override exists [0.02ms]
✓ usesAutoOgImage > respects config and frontmatter image overrides [0.01ms]

packages/mdx-bundler/src/markdown/headings.test.ts:
✓ extractHeadingNodes > strips HTML and markdown link syntax from heading titles [0.73ms]
✓ extractHeadingNodes > keeps plain heading titles [0.02ms]
✓ extractHeadingNodes > extracts markdown link label without URL [0.01ms]

packages/mdx-bundler/src/docs-ir/sanitize-html.test.ts:
✓ sanitizeHtml > removes script tags and event handlers [3.81ms]
✓ sanitizeHtml > preserves safe badge-style HTML [0.83ms]
✓ sanitizeHtml > strips javascript: URLs [0.14ms]
✓ sanitizeHtml > preserves safe iframe embeds [0.37ms]
✓ sanitizeHtml > strips javascript: iframe src [0.11ms]
✓ sanitizeHtml > preserves class on i tags for Font Awesome icons [0.12ms]
✓ sanitizeHtml > converts markdown image links embedded in HTML table cells [0.50ms]

packages/mdx-bundler/src/docs-ir/from-mdx.test.ts:
✓ preprocessMdxSource > strips HTML comments [0.05ms]
✓ preprocessMdxSource > escapes angle brackets that cannot start JSX [0.01ms]
✓ mdxToDocIr > does not throw on HTML comments [3.62ms]
✓ mdxToDocIr > does not throw on wildcard angle brackets [1.05ms]
✓ mdxToDocIr > parses known MDX components [1.66ms]
✓ mdxToDocIr > keeps inline links in a single markdown leaf inside components [1.27ms]
✓ mdxToDocIr > renders lowercase HTML tags as html IR nodes [1.13ms]
✓ mdxToDocIr > preserves iframe embeds in html IR nodes [0.71ms]
✓ mdxToDocIr > falls back to markdown-only parse when MDX still fails [0.41ms]
✓ mdxToDocIr > parses inline TabItem siblings inside Tabs as components [1.24ms]
✓ mdxToDocIr > keeps GFM tables with inline code and br tags in a single markdown leaf [1.29ms]
✓ mdxToDocIr > parses Info and code blocks inside list items as structured IR [1.53ms]
✓ mdxToDocIr > parses Info and code blocks inside Step list items [0.87ms]
✓ mdxToDocIr > normalizes indented GFM tables inside Step components [0.73ms]
---------------------------------------------------|---------|---------|-------------------
File                                               | % Funcs | % Lines | Uncovered Line #s
---------------------------------------------------|---------|---------|-------------------
All files                                          |   60.67 |   66.65 |
 app/src/lib/docs-links.ts                         |   50.00 |   85.71 | 
 app/src/lib/docs-nav.ts                           |   57.14 |   49.49 | 9,37,39-42,74-86,91-99,106-127
 app/src/lib/docs-paths.ts                         |   15.38 |   22.22 | 12-26,30-34,39-68,103-105,109-119,123,127-137,141,145,152,160-199
 app/src/server/github/ref-validation.ts           |  100.00 |  100.00 | 
 packages/cli/src/lib/docs-config.ts               |   33.33 |   31.82 | 13-20,24-40,44-47,51-57,81,85-92
 packages/cli/src/lib/errors.ts                    |    0.00 |   31.58 | 6-8,13-17,21-24
 packages/mdx-bundler/src/docs-ir/from-mdx.ts      |   79.41 |   66.16 | 90,157,170,172,178-179,185,215-216,218-220,222,232,237-239,271,273,286-291,299,301,308,310-312,314,329-330,340,342-343,351-363,367-405,409-417,421-424,438-439,450,457-458,474,476-478
 packages/mdx-bundler/src/docs-ir/sanitize-html.ts |  100.00 |   98.41 | 
 packages/mdx-bundler/src/docs-ir/visit.ts         |  100.00 |  100.00 | 
 packages/mdx-bundler/src/markdown/headings.ts     |   71.43 |   81.05 | 24,35-42,44,88,90-93,95,121
---------------------------------------------------|---------|---------|-------------------

 37 pass
 0 fail
 85 expect() calls
Ran 37 tests across 6 files. [192.00ms]
```