### PR TITLE
docs: clarify GA per-page tracking requires frontmatter title

### DIFF
--- a/docs/customize/analytics.mdx
+++ b/docs/customize/analytics.mdx
@@ -100,9 +100,9 @@ Open a **live** docs URL (not the local preview shell) and confirm the provider 
    - Plausible: `script.js` from `plausible.io` or your self-hosted URL
 3. **Confirm events in the provider dashboard:** GTM Preview or Tag Assistant for Tag Manager; GA4 **Realtime** for direct GA; Plausible dashboard for page views on your mapped domain.
 
-<Warning>
+<Info>
   For Google Analytics, set `title` in frontmatter on every page. GA reads `page_title` from the document `<title>`. Without a per-page title, every route shares your site `name` from `docs.json` (or `"Documentation"`) as the page title, even though URLs still differ. Body `#` headings do not set the document title. See [Per-page titles in Google Analytics](/features/analytics#per-page-titles-in-google-analytics).
-</Warning>
+</Info>
 
 <Info>
   On the default `docs.page/{owner}/{repo}` path with no custom domain, GTM and GA still load when configured. Plausible stays inactive until a domain is resolved.

--- a/docs/customize/analytics.mdx
+++ b/docs/customize/analytics.mdx
@@ -100,6 +100,10 @@ Open a **live** docs URL (not the local preview shell) and confirm the provider 
    - Plausible: `script.js` from `plausible.io` or your self-hosted URL
 3. **Confirm events in the provider dashboard:** GTM Preview or Tag Assistant for Tag Manager; GA4 **Realtime** for direct GA; Plausible dashboard for page views on your mapped domain.
 
+<Warning>
+  For Google Analytics, set `title` in frontmatter on every page. GA reads `page_title` from the document `<title>`. Without a per-page title, every route shares your site `name` from `docs.json` (or `"Documentation"`) as the page title, even though URLs still differ. Body `#` headings do not set the document title. See [Per-page titles in Google Analytics](/features/analytics#per-page-titles-in-google-analytics).
+</Warning>
+
 <Info>
   On the default `docs.page/{owner}/{repo}` path with no custom domain, GTM and GA still load when configured. Plausible stays inactive until a domain is resolved.
 </Info>
@@ -110,6 +114,7 @@ Open a **live** docs URL (not the local preview shell) and confirm the provider 
 | --- | --- | --- |
 | No analytics scripts in local preview | Expected (preview mode suppresses `scripts`) | Verify on a published or branch-preview URL |
 | GA4 script missing but GTM is configured | GTM takes precedence over direct GA | Add GA as a tag inside GTM, or remove `googleTagManager` to use direct GA |
+| GA shows one page title for every route | Pages missing frontmatter `title` | Add `title` to each page's YAML frontmatter (body `#` headings do not count); see [Page frontmatter](/reference/page-frontmatter) |
 | Plausible script never loads | No custom domain or vanity subdomain on the request | Use a [vanity subdomain](/features/vanity-subdomains) or [request a custom domain](/customize/custom-domain), then open the site on that hostname |
 | Plausible loads but no page views | `data-domain` must match the hostname readers use | Confirm the domain in Plausible matches your docs domain exactly |
 | Scripts present but no dashboard data | Provider misconfiguration or ad blockers | Check container or measurement ID spelling; test in a clean browser profile |

--- a/docs/features/analytics.mdx
+++ b/docs/features/analytics.mdx
@@ -31,6 +31,24 @@ When `googleTagManager` is set, docs.page injects the GTM bootstrap script only.
 
 Set `googleAnalytics` alone when you want a direct GA4 integration without Tag Manager.
 
+### Per-page titles in Google Analytics
+
+Google Analytics reads `page_title` from the document `<title>` on each `page_view` event. docs.page sets that tag from each page's frontmatter `title`, then falls back to `name` in `docs.json`, then `"Documentation"`. When a page omits frontmatter `title`, every route shares the same `page_title` in GA even though `page_location` / `page_path` still differ by URL.
+
+A Markdown `#` heading in the page body does **not** set the document title. Only YAML frontmatter does.
+
+Give every `.md` or `.mdx` file its own `title` in YAML frontmatter:
+
+```yaml
+---
+title: Your Page Title
+---
+```
+
+This applies whether GA loads directly from `googleAnalytics` or through a GA tag in Google Tag Manager. docs.page only injects the GTM bootstrap script; you configure the GA tag in your container.
+
+See [Page frontmatter](/reference/page-frontmatter) and [Write: Frontmatter](/authoring/write#frontmatter).
+
 ### Plausible and site domains
 
 Plausible requires a `data-domain` attribute that matches the hostname readers use. docs.page loads the Plausible script only when the request resolves to a configured **custom domain** or **vanity subdomain**. On the default `docs.page/{owner}/{repo}` path with no mapped domain, Plausible config has no effect.


### PR DESCRIPTION
Fixes #457

## Summary

- Document that Google Analytics reads `page_title` from the document `<title>`, which docs.page sets from frontmatter `title` (falling back to `docs.json` `name`, then `"Documentation"`).
- Add a troubleshooting row and verify warning in the analytics customize guide.
- Note that body `#` headings do not set the document title, and that GTM users configure GA tags in their container.

## Scope

- [ ] `app/` (hosted site, MCP, Ask AI)
- [ ] `packages/cli/`
- [ ] `packages/mdx-bundler/`
- [x] `docs/` (product documentation)
- [ ] Repo / CI / other

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / chore

## Test plan

- [x] `bun run check` passes locally
- [x] Tested locally (`bun dev`, CLI command, or other relevant command)
- [x] Updated `docs/` (if user-facing)
- [ ] Verified on a docs.page URL or local preview (if rendering/routing changed)

## Notes for reviewers

Docs-only change. Closes the documentation gap from #296 / #457 — no code changes to analytics injection.

Made with [Cursor](https://cursor.com)