### PR TITLE
docs: quote npx package name for PowerShell on Windows

### DIFF
--- a/docs/features/cli.mdx
+++ b/docs/features/cli.mdx
@@ -42,6 +42,10 @@ To try a command without a global install, prefix it with `npx`:
 npx @docs.page/cli [command]
 ```
 
+<Info>
+  **Windows (PowerShell):** quote the package name: `npx '@docs.page/cli' [command]`.
+</Info>
+
 `npx` downloads the package when needed and runs it immediately. This works well for one-off scaffolding or CI jobs.
 
 ### Install globally

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -19,6 +19,10 @@ description: Publish a live documentation site from a public GitHub repository i
     npx @docs.page/cli init
     ```
 
+    <Info>
+      **Windows (PowerShell):** use `npx '@docs.page/cli' init` — PowerShell requires quotes around the package name.
+    </Info>
+
     The CLI asks for your project name and whether to create starter pages. Accept the defaults unless you already have a `docs/` directory you want to keep. See [CLI](/features/cli) for install options and flags.
 
     When init finishes, your project contains:


### PR DESCRIPTION
Fixes #415

## Summary

- Add short PowerShell callouts in Quickstart and CLI install docs so Windows users are aware that they need to quote the package name when running `npx`.

## Scope

- [ ] `app/` (hosted site, MCP, Ask AI)
- [ ] `packages/cli/`
- [ ] `packages/mdx-bundler/`
- [x] `docs/` (product documentation)
- [ ] Repo / CI / other

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / chore

## Test plan

- [x] `bun run check` passes locally
- [ ] Tested locally (`bun dev`, CLI command, or other relevant command)
- [x] Updated `docs/` (if user-facing)
- [ ] Verified on a docs.page URL or local preview (if rendering/routing changed)

Made with [Cursor](https://cursor.com)