### PR TITLE
Tint homepage feature cards with distinct secondary colours

### DIFF
--- a/app/src/components/homepage/features/data.tsx
+++ b/app/src/components/homepage/features/data.tsx
@@ -14,6 +14,7 @@ export const features = [
       "Let users' AI agents query your documentation. Built-in MCP servers alongside llms.txt files allow LLMs to ingest your product context instantly.",
     video: "/_docs.page/agent-ready.mp4?v=2",
     link: "/agent-access",
+    accent: "var(--color-honey-400)",
   },
   {
     titleText: "Git Publishing",
@@ -26,6 +27,7 @@ export const features = [
       "Deploy updates directly from your public GitHub repository. Eliminate build pipelines, hosting configuration, or infrastructure maintenance.",
     image: gitPublishing,
     link: "/git-publishing",
+    accent: "var(--color-periwinkle-400)",
   },
   {
     titleText: "Intelligent Search",
@@ -38,6 +40,7 @@ export const features = [
       "Index content automatically and provide an embedded AI chat. Locate information instantly without third-party tracking scripts or external setup.",
     video: "/_docs.page/intelligent-search.mp4?v=2",
     link: "/intelligent-search",
+    accent: "#63D0BD",
   },
   {
     titleText: "Markdown Components",
@@ -50,6 +53,7 @@ export const features = [
       "Add interactive components to your docs with MDX for richer experiences than standard Markdown.",
     video: "/_docs.page/markdown-components.mp4",
     link: "/markdown-components?v=2",
+    accent: "#A68BF3",
   },
   {
     titleText: "Branches & versions",
@@ -62,6 +66,7 @@ export const features = [
       "Serve any Git branch, tag, or release as a distinct documentation site. Seamlessly organise versions and live staging previews on the fly.",
     image: branches,
     link: "/agent-ready",
+    accent: "#E99363",
   },
   {
     titleText: "Modern Interface",
@@ -74,5 +79,6 @@ export const features = [
       "Style your docs site using shadcn/ui design standards. Customize components easily to match your brand identity.",
     component: <ModernInterface />,
     link: "/modern-interface",
+    accent: "#E96767",
   },
 ];

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -1,6 +1,6 @@
 import { RiArrowRightSLine } from "@remixicon/react";
 import Link from "next/link";
-import type { PropsWithChildren } from "react";
+import type { CSSProperties, PropsWithChildren } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "../../ui/button";
 import {
@@ -14,12 +14,14 @@ type FeatureCardProps = PropsWithChildren<{
   title: React.ReactNode;
   description: string;
   link: string;
+  accent: string;
 }>;
 
 export function FeatureCard({
   title,
   description,
   link,
+  accent,
   children,
 }: FeatureCardProps) {
   return (
@@ -27,9 +29,16 @@ export function FeatureCard({
       className={cn(
         PAPER_SECTION_SHELL_CLASS,
         PAPER_SECTION_OVERLAP_CLASS,
-        "bg-black/60 pb-20 lg:pb-40",
+        "pb-20 lg:pb-40",
       )}
-      style={{ clipPath: paperCornerClipPath() }}
+      style={
+        {
+          clipPath: paperCornerClipPath(),
+          "--paper-edge": accent,
+          borderColor: accent,
+          backgroundColor: `color-mix(in srgb, ${accent} 12%, rgb(0 0 0 / 0.6))`,
+        } as CSSProperties
+      }
     >
       <PaperCorner />
       <div className="mx-auto flex flex-col max-w-8xl space-y-8">

--- a/app/src/components/homepage/features/features.tsx
+++ b/app/src/components/homepage/features/features.tsx
@@ -24,6 +24,7 @@ export function Features() {
           title={feature.title}
           description={feature.description}
           link={feature.link}
+          accent={feature.accent}
         >
           <FeatureMedia>
             {feature.video ? (

--- a/app/src/components/homepage/paper-corner.tsx
+++ b/app/src/components/homepage/paper-corner.tsx
@@ -36,9 +36,12 @@ const STROKE_WIDTH_PROPS = {
   vectorEffect: "non-scaling-stroke" as const,
 };
 
+const PAPER_EDGE = "var(--paper-edge, var(--color-border))";
+
 const STROKE_SOLID_PROPS = {
   ...STROKE_WIDTH_PROPS,
   className: "stroke-border",
+  stroke: PAPER_EDGE,
 };
 
 /** Feature cards: black tint + backdrop blur (matches landing-page-new-branding-v2). */
@@ -101,6 +104,7 @@ export function PaperCorner({
           borderGradient ? styles.homepageLineHGradientFold : "bg-border",
           className,
         )}
+        style={borderGradient ? undefined : { backgroundColor: PAPER_EDGE }}
       />
       <div
         aria-hidden


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small visual test for the preview deploy: each of the six homepage feature cards now uses a distinct docs.page / Invertase secondary for its **shell fill and edge**, including the existing folded paper corner so the dog-ear still reads as the same card.

Colours come from tokens already in `globals.css` (honey, periwinkle) and the Invertase secondaries already used on the homepage Explore row (teal, lavender, warm orange, coral).

**This is a small test PR** so the coloured shells can be checked on the preview deploy.

## Scope

- [x] `app/` (hosted site, MCP, Ask AI)
- [ ] `packages/cli/`
- [ ] `packages/mdx-bundler/`
- [ ] `docs/` (product documentation)
- [ ] Repo / CI / other

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / chore

## What did not change

- Folded paper corner is **kept** (`PaperCorner`, `paperCornerClipPath`, `PAPER_SECTION_OVERLAP_CLASS`)
- Copy, titles, Learn more, media
- Overlap amount, grid, nav, hero, footer
- Layout, type treatment, index numbers, sticky pile (not copied from mock)

## Test plan

- [x] `bun run check` passes locally
- [x] Tested locally (`bun dev`) — all six cards keep the top-left dog-ear; each has a distinct tinted fill + coloured edge that also strokes the fold
- [ ] Updated `docs/` (if user-facing)
- [ ] Verified on a docs.page URL or local preview (if rendering/routing changed)

Please check the homepage feature cards on the preview deploy: six distinct tinted shells, dog-ear still present on every card.

[Honey and periwinkle feature card shells](https://cursor.com/agents/bc-366626b3-aac5-4981-a41b-5992422a647c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffeature-cards-honey-periwinkle.webp)
[Teal and lavender feature card shells](https://cursor.com/agents/bc-366626b3-aac5-4981-a41b-5992422a647c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffeature-cards-teal-lavender.webp)
[Lavender and warm orange feature card shells](https://cursor.com/agents/bc-366626b3-aac5-4981-a41b-5992422a647c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ffeature-cards-lavender-orange.webp)

## Notes for reviewers

Preview-deploy visual check only. No behaviour, routing, or copy changes.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-366626b3-aac5-4981-a41b-5992422a647c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-366626b3-aac5-4981-a41b-5992422a647c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

