### PR TITLE
feat: sticky-scroll pile for homepage feature cards

### DIFF
--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -30,7 +30,7 @@ export function FeatureCard({
       style={{ top: `${index}rem`, zIndex: index + 1 }}
     >
       <div
-        className={cn(PAPER_SECTION_SHELL_CLASS, "bg-black/60 pb-20 lg:pb-40")}
+        className={cn(PAPER_SECTION_SHELL_CLASS, "bg-black pb-20 lg:pb-40")}
         style={{ clipPath: paperCornerClipPath() }}
       >
         <PaperCorner />

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -26,8 +26,9 @@ export function FeatureCard({
 }: FeatureCardProps) {
   return (
     <div
-      className={cn(PAPER_SECTION_OVERLAP_CLASS, "sticky")}
-      style={{ top: `${index}rem`, zIndex: index + 1 }}
+      data-stack-card
+      className={cn(PAPER_SECTION_OVERLAP_CLASS, "sticky top-0")}
+      style={{ zIndex: index + 1 }}
     >
       <div
         className={cn(PAPER_SECTION_SHELL_CLASS, "bg-black pb-20 lg:pb-40")}

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -27,8 +27,8 @@ export function FeatureCard({
   return (
     <div
       data-stack-card
-      className={cn(PAPER_SECTION_OVERLAP_CLASS, "sticky top-0")}
-      style={{ zIndex: index + 1 }}
+      className={cn(PAPER_SECTION_OVERLAP_CLASS, "sticky")}
+      style={{ top: `${index}rem`, zIndex: index + 1 }}
     >
       <div
         className={cn(PAPER_SECTION_SHELL_CLASS, "bg-black pb-20 lg:pb-40")}

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -14,47 +14,50 @@ type FeatureCardProps = PropsWithChildren<{
   title: React.ReactNode;
   description: string;
   link: string;
+  index: number;
 }>;
 
 export function FeatureCard({
   title,
   description,
   link,
+  index,
   children,
 }: FeatureCardProps) {
   return (
     <div
-      className={cn(
-        PAPER_SECTION_SHELL_CLASS,
-        PAPER_SECTION_OVERLAP_CLASS,
-        "bg-black/60 pb-20 lg:pb-40",
-      )}
-      style={{ clipPath: paperCornerClipPath() }}
+      className={cn(PAPER_SECTION_OVERLAP_CLASS, "sticky")}
+      style={{ top: `${index}rem`, zIndex: index + 1 }}
     >
-      <PaperCorner />
-      <div className="mx-auto flex flex-col max-w-8xl space-y-8">
-        <div className="px-6 pt-8 lg:pl-26 lg:pr-0"></div>
-        <div className="mt-8 lg:mt-0 grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)] lg:gap-0">
-          <div className="flex flex-col gap-4 px-6 space-y-6 lg:mt-12 lg:px-20">
-            <h4 className="text-2xl font-extralight font-heading text-neutral-300 lg:text-3xl">
-              {title}
-            </h4>
-            <p className="text-neutral-400 font-extralight">{description}</p>
-            <div>
-              <Button
-                variant="outline"
-                asChild
-                className="group rounded-full dark:border-primary bg-transparent font-light text-primary hover:text-primary hover:bg-primary/10"
-              >
-                <Link href={link}>
-                  <span>Learn more</span>
-                  <RiArrowRightSLine className="size-5 group-hover:translate-x-1 transition-transform" />
-                </Link>
-              </Button>
+      <div
+        className={cn(PAPER_SECTION_SHELL_CLASS, "bg-black/60 pb-20 lg:pb-40")}
+        style={{ clipPath: paperCornerClipPath() }}
+      >
+        <PaperCorner />
+        <div className="mx-auto flex flex-col max-w-8xl space-y-8">
+          <div className="px-6 pt-8 lg:pl-26 lg:pr-0"></div>
+          <div className="mt-8 lg:mt-0 grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)] lg:gap-0">
+            <div className="flex flex-col gap-4 px-6 space-y-6 lg:mt-12 lg:px-20">
+              <h4 className="text-2xl font-extralight font-heading text-neutral-300 lg:text-3xl">
+                {title}
+              </h4>
+              <p className="text-neutral-400 font-extralight">{description}</p>
+              <div>
+                <Button
+                  variant="outline"
+                  asChild
+                  className="group rounded-full dark:border-primary bg-transparent font-light text-primary hover:text-primary hover:bg-primary/10"
+                >
+                  <Link href={link}>
+                    <span>Learn more</span>
+                    <RiArrowRightSLine className="size-5 group-hover:translate-x-1 transition-transform" />
+                  </Link>
+                </Button>
+              </div>
             </div>
-          </div>
-          <div className="relative flex items-center justify-center px-6 pb-8 lg:pr-20 lg:px-0 lg:pb-0">
-            {children}
+            <div className="relative flex items-center justify-center px-6 pb-8 lg:pr-20 lg:px-0 lg:pb-0">
+              {children}
+            </div>
           </div>
         </div>
       </div>

--- a/app/src/components/homepage/features/features.tsx
+++ b/app/src/components/homepage/features/features.tsx
@@ -1,7 +1,30 @@
+"use client";
+
 import Image from "next/image";
-import type { PropsWithChildren } from "react";
+import { type PropsWithChildren, useLayoutEffect, useRef } from "react";
 import { features } from "./data";
 import { FeatureCard } from "./feature-card";
+
+function stretchStack(container: HTMLElement) {
+  const cards = [
+    ...container.querySelectorAll<HTMLElement>("[data-stack-card]"),
+  ];
+  if (cards.length === 0) return;
+  const parentHeight = container.scrollHeight;
+  const metrics = cards.map((card) => {
+    const inner = card.firstElementChild as HTMLElement | null;
+    return {
+      card,
+      top: card.offsetTop,
+      visual: inner?.offsetHeight ?? card.offsetHeight,
+    };
+  });
+  for (const { card, top, visual } of metrics) {
+    const extra = Math.max(0, parentHeight - top - visual);
+    card.style.paddingBottom = extra ? `${extra}px` : "";
+    card.style.marginBottom = extra ? `-${extra}px` : "";
+  }
+}
 
 function FeatureMedia({ children }: PropsWithChildren) {
   return (
@@ -16,8 +39,30 @@ function FeatureMedia({ children }: PropsWithChildren) {
 }
 
 export function Features() {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    const container = ref.current;
+    if (!container) return;
+
+    const apply = () => stretchStack(container);
+    apply();
+
+    const ro = new ResizeObserver(apply);
+    ro.observe(container);
+    for (const card of container.querySelectorAll("[data-stack-card]")) {
+      const inner = card.firstElementChild;
+      if (inner) ro.observe(inner);
+    }
+    window.addEventListener("resize", apply);
+    return () => {
+      ro.disconnect();
+      window.removeEventListener("resize", apply);
+    };
+  }, []);
+
   return (
-    <div className="relative z-10 -mb-[70svh]">
+    <div ref={ref} className="relative -mb-[100svh]">
       {features.map((feature, i) => (
         <FeatureCard
           key={i}
@@ -44,7 +89,7 @@ export function Features() {
           </FeatureMedia>
         </FeatureCard>
       ))}
-      <div aria-hidden className="h-[70svh]" />
+      <div aria-hidden className="h-[100svh]" />
     </div>
   );
 }

--- a/app/src/components/homepage/features/features.tsx
+++ b/app/src/components/homepage/features/features.tsx
@@ -17,7 +17,7 @@ function FeatureMedia({ children }: PropsWithChildren) {
 
 export function Features() {
   return (
-    <div>
+    <div className="relative z-10 pb-[50svh] -mb-[50svh]">
       {features.map((feature, i) => (
         <FeatureCard
           key={i}

--- a/app/src/components/homepage/features/features.tsx
+++ b/app/src/components/homepage/features/features.tsx
@@ -34,24 +34,33 @@ export function Features({ children }: PropsWithChildren) {
 
     const lock = () => {
       if (lockY.current != null) return;
-      const last = cards().at(-1);
+      const list = cards();
+      const last = list.at(-1);
       if (!last) return;
 
-      const gap =
-        last.getBoundingClientRect().top - stack.getBoundingClientRect().top;
+      const targetTop = last.getBoundingClientRect().top;
       const pileHeight = last.offsetHeight;
+      const preserved = stack.offsetHeight - pileHeight;
+      const y = window.scrollY;
 
       adjusting.current = true;
-      spacer.style.height = `${Math.max(0, gap)}px`;
       stack.style.height = `${pileHeight}px`;
       stack.style.position = "relative";
-      for (const card of cards()) {
+      for (const card of list) {
         card.style.position = "absolute";
         card.style.top = "0px";
         card.style.left = "0px";
         card.style.right = "0px";
         card.style.marginTop = "0px";
       }
+      spacer.style.height = `${Math.max(0, preserved)}px`;
+
+      const stackedTop = list[0].getBoundingClientRect().top;
+      const delta = targetTop - stackedTop;
+      if (delta !== 0) {
+        spacer.style.height = `${Math.max(0, preserved + delta)}px`;
+      }
+      window.scrollTo(0, y);
       lockY.current = window.scrollY;
       adjusting.current = false;
     };

--- a/app/src/components/homepage/features/features.tsx
+++ b/app/src/components/homepage/features/features.tsx
@@ -17,35 +17,34 @@ function FeatureMedia({ children }: PropsWithChildren) {
   );
 }
 
-export function Features() {
-  const outerRef = useRef<HTMLDivElement>(null);
-  const innerRef = useRef<HTMLDivElement>(null);
+export function Features({ children }: PropsWithChildren) {
+  const spacerRef = useRef<HTMLDivElement>(null);
+  const stackRef = useRef<HTMLDivElement>(null);
   const lockY = useRef<number | null>(null);
+  const adjusting = useRef(false);
 
   useEffect(() => {
-    const outer = outerRef.current;
-    const inner = innerRef.current;
-    if (!outer || !inner) return;
+    const spacer = spacerRef.current;
+    const stack = stackRef.current;
+    if (!spacer || !stack) return;
 
     const cards = () => [
-      ...inner.querySelectorAll<HTMLElement>("[data-stack-card]"),
+      ...stack.querySelectorAll<HTMLElement>("[data-stack-card]"),
     ];
-
-    const pinInner = () => {
-      const rect = outer.getBoundingClientRect();
-      inner.style.position = "fixed";
-      inner.style.top = "0px";
-      inner.style.left = `${rect.left}px`;
-      inner.style.width = `${rect.width}px`;
-      inner.style.height = `${window.innerHeight}px`;
-      inner.style.zIndex = "10";
-    };
 
     const lock = () => {
       if (lockY.current != null) return;
-      lockY.current = window.scrollY;
-      outer.style.height = `${inner.offsetHeight}px`;
-      pinInner();
+      const last = cards().at(-1);
+      if (!last) return;
+
+      const gap =
+        last.getBoundingClientRect().top - stack.getBoundingClientRect().top;
+      const pileHeight = last.offsetHeight;
+
+      adjusting.current = true;
+      spacer.style.height = `${Math.max(0, gap)}px`;
+      stack.style.height = `${pileHeight}px`;
+      stack.style.position = "relative";
       for (const card of cards()) {
         card.style.position = "absolute";
         card.style.top = "0px";
@@ -53,19 +52,17 @@ export function Features() {
         card.style.right = "0px";
         card.style.marginTop = "0px";
       }
+      lockY.current = window.scrollY;
+      adjusting.current = false;
     };
 
     const unlock = () => {
       if (lockY.current == null) return;
+      adjusting.current = true;
       lockY.current = null;
-      outer.style.height = "";
-      inner.style.position = "";
-      inner.style.top = "";
-      inner.style.left = "";
-      inner.style.width = "";
-      inner.style.height = "";
-      inner.style.zIndex = "";
-      inner.style.transform = "";
+      spacer.style.height = "";
+      stack.style.height = "";
+      stack.style.position = "";
       for (const card of cards()) {
         card.style.position = "";
         card.style.top = "";
@@ -73,22 +70,18 @@ export function Features() {
         card.style.right = "";
         card.style.marginTop = "";
       }
+      adjusting.current = false;
     };
 
     const onScroll = () => {
+      if (adjusting.current) return;
       const last = cards().at(-1);
       if (!last) return;
       if (lockY.current == null) {
         if (last.getBoundingClientRect().top <= 1) lock();
         return;
       }
-      const progress = window.scrollY - lockY.current;
-      if (progress < 0) {
-        unlock();
-        return;
-      }
-      pinInner();
-      inner.style.transform = `translateY(${-progress}px)`;
+      if (window.scrollY < lockY.current) unlock();
     };
 
     window.addEventListener("scroll", onScroll, { passive: true });
@@ -102,8 +95,9 @@ export function Features() {
   }, []);
 
   return (
-    <div ref={outerRef}>
-      <div ref={innerRef}>
+    <div style={{ overflowAnchor: "none" }}>
+      <div ref={spacerRef} aria-hidden className="pointer-events-none" />
+      <div ref={stackRef}>
         {features.map((feature, i) => (
           <FeatureCard
             key={i}
@@ -135,6 +129,7 @@ export function Features() {
           </FeatureCard>
         ))}
       </div>
+      {children}
     </div>
   );
 }

--- a/app/src/components/homepage/features/features.tsx
+++ b/app/src/components/homepage/features/features.tsx
@@ -38,8 +38,9 @@ export function Features({ children }: PropsWithChildren) {
       const last = list.at(-1);
       if (!last) return;
 
-      const targetTop = last.getBoundingClientRect().top;
-      const pileHeight = last.offsetHeight;
+      const stop = Number.parseFloat(getComputedStyle(last).top) || 0;
+      const targetTop = list[0].getBoundingClientRect().top;
+      const pileHeight = last.offsetHeight + stop;
       const preserved = stack.offsetHeight - pileHeight;
       const y = window.scrollY;
 
@@ -48,7 +49,6 @@ export function Features({ children }: PropsWithChildren) {
       stack.style.position = "relative";
       for (const card of list) {
         card.style.position = "absolute";
-        card.style.top = "0px";
         card.style.left = "0px";
         card.style.right = "0px";
         card.style.marginTop = "0px";
@@ -74,7 +74,6 @@ export function Features({ children }: PropsWithChildren) {
       stack.style.position = "";
       for (const card of cards()) {
         card.style.position = "";
-        card.style.top = "";
         card.style.left = "";
         card.style.right = "";
         card.style.marginTop = "";
@@ -87,7 +86,8 @@ export function Features({ children }: PropsWithChildren) {
       const last = cards().at(-1);
       if (!last) return;
       if (lockY.current == null) {
-        if (last.getBoundingClientRect().top <= 1) lock();
+        const stop = Number.parseFloat(getComputedStyle(last).top) || 0;
+        if (last.getBoundingClientRect().top <= stop + 1) lock();
         return;
       }
       if (window.scrollY < lockY.current) unlock();

--- a/app/src/components/homepage/features/features.tsx
+++ b/app/src/components/homepage/features/features.tsx
@@ -1,30 +1,9 @@
 "use client";
 
 import Image from "next/image";
-import { type PropsWithChildren, useLayoutEffect, useRef } from "react";
+import { type PropsWithChildren, useEffect, useRef } from "react";
 import { features } from "./data";
 import { FeatureCard } from "./feature-card";
-
-function stretchStack(container: HTMLElement) {
-  const cards = [
-    ...container.querySelectorAll<HTMLElement>("[data-stack-card]"),
-  ];
-  if (cards.length === 0) return;
-  const parentHeight = container.scrollHeight;
-  const metrics = cards.map((card) => {
-    const inner = card.firstElementChild as HTMLElement | null;
-    return {
-      card,
-      top: card.offsetTop,
-      visual: inner?.offsetHeight ?? card.offsetHeight,
-    };
-  });
-  for (const { card, top, visual } of metrics) {
-    const extra = Math.max(0, parentHeight - top - visual);
-    card.style.paddingBottom = extra ? `${extra}px` : "";
-    card.style.marginBottom = extra ? `-${extra}px` : "";
-  }
-}
 
 function FeatureMedia({ children }: PropsWithChildren) {
   return (
@@ -39,57 +18,123 @@ function FeatureMedia({ children }: PropsWithChildren) {
 }
 
 export function Features() {
-  const ref = useRef<HTMLDivElement>(null);
+  const outerRef = useRef<HTMLDivElement>(null);
+  const innerRef = useRef<HTMLDivElement>(null);
+  const lockY = useRef<number | null>(null);
 
-  useLayoutEffect(() => {
-    const container = ref.current;
-    if (!container) return;
+  useEffect(() => {
+    const outer = outerRef.current;
+    const inner = innerRef.current;
+    if (!outer || !inner) return;
 
-    const apply = () => stretchStack(container);
-    apply();
+    const cards = () => [
+      ...inner.querySelectorAll<HTMLElement>("[data-stack-card]"),
+    ];
 
-    const ro = new ResizeObserver(apply);
-    ro.observe(container);
-    for (const card of container.querySelectorAll("[data-stack-card]")) {
-      const inner = card.firstElementChild;
-      if (inner) ro.observe(inner);
-    }
-    window.addEventListener("resize", apply);
+    const pinInner = () => {
+      const rect = outer.getBoundingClientRect();
+      inner.style.position = "fixed";
+      inner.style.top = "0px";
+      inner.style.left = `${rect.left}px`;
+      inner.style.width = `${rect.width}px`;
+      inner.style.height = `${window.innerHeight}px`;
+      inner.style.zIndex = "10";
+    };
+
+    const lock = () => {
+      if (lockY.current != null) return;
+      lockY.current = window.scrollY;
+      outer.style.height = `${inner.offsetHeight}px`;
+      pinInner();
+      for (const card of cards()) {
+        card.style.position = "absolute";
+        card.style.top = "0px";
+        card.style.left = "0px";
+        card.style.right = "0px";
+        card.style.marginTop = "0px";
+      }
+    };
+
+    const unlock = () => {
+      if (lockY.current == null) return;
+      lockY.current = null;
+      outer.style.height = "";
+      inner.style.position = "";
+      inner.style.top = "";
+      inner.style.left = "";
+      inner.style.width = "";
+      inner.style.height = "";
+      inner.style.zIndex = "";
+      inner.style.transform = "";
+      for (const card of cards()) {
+        card.style.position = "";
+        card.style.top = "";
+        card.style.left = "";
+        card.style.right = "";
+        card.style.marginTop = "";
+      }
+    };
+
+    const onScroll = () => {
+      const last = cards().at(-1);
+      if (!last) return;
+      if (lockY.current == null) {
+        if (last.getBoundingClientRect().top <= 1) lock();
+        return;
+      }
+      const progress = window.scrollY - lockY.current;
+      if (progress < 0) {
+        unlock();
+        return;
+      }
+      pinInner();
+      inner.style.transform = `translateY(${-progress}px)`;
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    window.addEventListener("resize", onScroll);
+    onScroll();
     return () => {
-      ro.disconnect();
-      window.removeEventListener("resize", apply);
+      window.removeEventListener("scroll", onScroll);
+      window.removeEventListener("resize", onScroll);
+      unlock();
     };
   }, []);
 
   return (
-    <div ref={ref} className="relative -mb-[100svh]">
-      {features.map((feature, i) => (
-        <FeatureCard
-          key={i}
-          index={i}
-          title={feature.title}
-          description={feature.description}
-          link={feature.link}
-        >
-          <FeatureMedia>
-            {feature.video ? (
-              <video
-                src={feature.video}
-                autoPlay
-                loop
-                muted
-                title={feature.titleText}
-                className="relative aspect-auto z-1 w-full rounded-lg object-cover border border-border/50 shadow-lg"
-              />
-            ) : null}
-            {feature.image ? (
-              <Image src={feature.image} alt={feature.titleText} className="" />
-            ) : null}
-            {feature.component ?? null}
-          </FeatureMedia>
-        </FeatureCard>
-      ))}
-      <div aria-hidden className="h-[100svh]" />
+    <div ref={outerRef}>
+      <div ref={innerRef}>
+        {features.map((feature, i) => (
+          <FeatureCard
+            key={i}
+            index={i}
+            title={feature.title}
+            description={feature.description}
+            link={feature.link}
+          >
+            <FeatureMedia>
+              {feature.video ? (
+                <video
+                  src={feature.video}
+                  autoPlay
+                  loop
+                  muted
+                  title={feature.titleText}
+                  className="relative aspect-auto z-1 w-full rounded-lg object-cover border border-border/50 shadow-lg"
+                />
+              ) : null}
+              {feature.image ? (
+                <Image
+                  src={feature.image}
+                  alt={feature.titleText}
+                  className=""
+                />
+              ) : null}
+              {feature.component ?? null}
+            </FeatureMedia>
+          </FeatureCard>
+        ))}
+      </div>
     </div>
   );
 }

--- a/app/src/components/homepage/features/features.tsx
+++ b/app/src/components/homepage/features/features.tsx
@@ -17,10 +17,11 @@ function FeatureMedia({ children }: PropsWithChildren) {
 
 export function Features() {
   return (
-    <>
+    <div>
       {features.map((feature, i) => (
         <FeatureCard
           key={i}
+          index={i}
           title={feature.title}
           description={feature.description}
           link={feature.link}
@@ -43,6 +44,6 @@ export function Features() {
           </FeatureMedia>
         </FeatureCard>
       ))}
-    </>
+    </div>
   );
 }

--- a/app/src/components/homepage/features/features.tsx
+++ b/app/src/components/homepage/features/features.tsx
@@ -17,7 +17,7 @@ function FeatureMedia({ children }: PropsWithChildren) {
 
 export function Features() {
   return (
-    <div className="relative z-10 pb-[50svh] -mb-[50svh]">
+    <div className="relative z-10 -mb-[70svh]">
       {features.map((feature, i) => (
         <FeatureCard
           key={i}
@@ -44,6 +44,7 @@ export function Features() {
           </FeatureMedia>
         </FeatureCard>
       ))}
+      <div aria-hidden className="h-[70svh]" />
     </div>
   );
 }

--- a/app/src/components/homepage/index.tsx
+++ b/app/src/components/homepage/index.tsx
@@ -98,9 +98,10 @@ export function Homepage() {
             <Header />
             <Hero />
             <Preview />
-            <Features />
-            <Explore />
-            <Footer />
+            <Features>
+              <Explore />
+              <Footer />
+            </Features>
           </div>
         </div>
       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Homepage feature cards now stick as you scroll, so each card piles on top of the previous one. Clip-path and the folded corner stay on an inner shell so the dog-ear does not fight sticky positioning.

### Review fixes

1. **Stacked look restored.** Each card uses `top: ${index}rem` again, so while scrolling the six features you see a pile (peek of the card below). Locking no longer flattens every card to `top: 0`.
2. **Last card joins the same pile.** Modern Interface sticks at its 5rem stop with the others, then the completed pile is locked in document flow.
3. **Completed pile leaves as one unit.** It does not unstack on the way out; it only unfolds when scrolling back up.
4. **Card shells are solid (`bg-black`).** Earlier titles and Learn more no longer show through the top card.
5. **Lower sections no longer slide under the pile.** Explore, the closer (“Bring your docs into the agentic age” + Get started), and the footer stay below the last card.
6. **No extra bar below the footer.** Removed the 100vh fixed inner / leftover sticky-range spacer that left a dark strip under Built by Invertase / © / Privacy / Terms.

## Scope

- [x] `app/` (hosted site, MCP, Ask AI)
- [ ] `packages/cli/`
- [ ] `packages/mdx-bundler/`
- [ ] `docs/` (product documentation)
- [ ] Repo / CI / other

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / chore

## What did not change

- Folded paper corner is **kept** (`PaperCorner`, `paperCornerClipPath`, `PAPER_SECTION_SHELL_CLASS`, `PAPER_SECTION_OVERLAP_CLASS`)
- Copy, titles, Learn more, media
- Nav, hero, preview
- Type treatment, index numbers, per-card colour tint, 2-column visual swap
- No colour-tint work from #534
- Mock type/colour from the pile reference is **not** copied — motion/layout only

## Test plan

- [x] `bun run check` passes locally
- [x] Tested locally (`bun dev`) — visible 1rem pile while scrolling features (cards land at 0/16/32/48/64/80px); last card joins with peek preserved; Explore / closer / footer stay below (not under) the last card; document height ends at the footer; unfolds on scroll-up; dog-ear on all six
- [ ] Updated `docs/` (if user-facing)
- [ ] Verified on a docs.page URL or local preview (if rendering/routing changed)

Georgina — please re-check the Railway preview ([docspage-docspage-pr-535.up.railway.app](https://docspage-docspage-pr-535.up.railway.app)): scrolling the six features should show a stacked pile again, and Explore / closer / footer should stay below the last card (never slide under).

## Notes for reviewers

Motion/layout only. Independent of #534 (colour tint, closing unmerged).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1596069b-fdd3-4772-9f0a-83f5edb325e7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1596069b-fdd3-4772-9f0a-83f5edb325e7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

