### PR TITLE
docs: fix Quickstart page writing

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -37,7 +37,8 @@ description: Publish a live documentation site from a public GitHub repository.
     - **`docs.json`**: site configuration (name, description, sidebar, and theme)
     - **`docs/index.mdx`**: your home page (served at `/`)
     - **`docs/next-steps.mdx`**: a second page (served at `/next-steps`)
-
+  </Step>
+  <Step title="Edit a starter page">
     Open `docs/index.mdx` and change the title or add a sentence so you can confirm your changes later on the live site.
   </Step>
   <Step title="Push to a public GitHub repository">

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -61,7 +61,7 @@ description: Publish a live documentation site from a public GitHub repository.
     https://docs.page/{owner}/{repo}
     ```
 
-    Your documentation is live the instant your push completes.
+    After the push completes, your documentation is available at this URL.
 
     For example, if your repository is `https://github.com/acme/my-docs`, your live site is `https://docs.page/acme/my-docs`.
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Quickstart
-description: Publish a live documentation site from a public GitHub repository in minutes.
+description: Publish a live documentation site from a public GitHub repository.
 ---
 
 **Before you begin**

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -25,7 +25,7 @@ description: Publish a live documentation site from a public GitHub repository.
 
     The CLI asks for your project name and whether to create starter pages. If you already have a `docs/` directory you want to keep, decline starter pages. Otherwise, accept the defaults. See [CLI](/features/cli) for install options and flags.
 
-    When init finishes, your project contains:
+    When `init` finishes, your project contains:
 
     ```text
     docs.json

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -7,7 +7,7 @@ description: Publish a live documentation site from a public GitHub repository.
 
 - A [GitHub](https://github.com) account
 - [Git](https://git-scm.com/downloads) installed locally
-- [Node.js](https://nodejs.org/) (to run the CLI via `npx`)
+- [Node.js](https://nodejs.org/) installed locally (to run the CLI with `npx`)
 
 ## Steps
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -54,11 +54,13 @@ description: Publish a live documentation site from a public GitHub repository.
     </Warning>
   </Step>
   <Step title="Open your live site">
-    Your documentation is live the instant your push completes. Open your browser and navigate to:
+    Open this URL in your browser:
 
     ```text
     https://docs.page/{owner}/{repo}
     ```
+
+    Your documentation is live the instant your push completes.
 
     For example, if your repository is `https://github.com/acme/my-docs`, your live site is `https://docs.page/acme/my-docs`.
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -23,7 +23,7 @@ description: Publish a live documentation site from a public GitHub repository.
       **Windows (PowerShell):** use `npx '@docs.page/cli' init` — PowerShell requires quotes around the package name.
     </Info>
 
-    The CLI asks for your project name and whether to create starter pages. Accept the defaults unless you already have a `docs/` directory you want to keep. See [CLI](/features/cli) for install options and flags.
+    The CLI asks for your project name and whether to create starter pages. If you already have a `docs/` directory you want to keep, decline starter pages. Otherwise, accept the defaults. See [CLI](/features/cli) for install options and flags.
 
     When init finishes, your project contains:
 


### PR DESCRIPTION
## Summary

- Apply style-guide fixes to `docs/quickstart.mdx`.
- One conventional commit per finding.

## Scope

- [x] `docs/` (product documentation)

## Type of change

- [x] Documentation

## Test plan

- [ ] `bun run check` passes locally
- [ ] Walk through the Quickstart steps on local preview