### PR TITLE
feat: landing-chrome 404 page for unknown routes

### DIFF
--- a/app/src/components/homepage/footer.tsx
+++ b/app/src/components/homepage/footer.tsx
@@ -2,38 +2,40 @@ import { RiArrowRightSLine } from "@remixicon/react";
 import Link from "next/link";
 import { Button } from "../ui/button";
 
-export function Footer() {
+export function Footer({ showCloser = true }: { showCloser?: boolean }) {
   return (
     <>
-      <div className="flex flex-col items-center gap-10 px-6 py-16 text-center lg:grid lg:grid-cols-2 lg:items-center lg:gap-0 lg:px-20 lg:py-32 lg:text-left">
-        <div className="order-2 flex flex-col items-center gap-8 lg:order-1 lg:items-start">
-          <h3 className="text-4xl leading-14 font-heading font-extralight tracking-loose lg:text-5xl">
-            Bring your docs <br /> into the{" "}
-            <span className="font-normal">agentic age</span>
-          </h3>
+      {showCloser ? (
+        <div className="flex flex-col items-center gap-10 px-6 py-16 text-center lg:grid lg:grid-cols-2 lg:items-center lg:gap-0 lg:px-20 lg:py-32 lg:text-left">
+          <div className="order-2 flex flex-col items-center gap-8 lg:order-1 lg:items-start">
+            <h3 className="text-4xl leading-14 font-heading font-extralight tracking-loose lg:text-5xl">
+              Bring your docs <br /> into the{" "}
+              <span className="font-normal">agentic age</span>
+            </h3>
 
-          <Button
-            variant="default"
-            size="lg"
-            className="rounded-full px-4 py-5 group"
-            asChild
-          >
-            {/* prefetch off + nofollow: see the hero CTA — the tracked redirect
+            <Button
+              variant="default"
+              size="lg"
+              className="rounded-full px-4 py-5 group"
+              asChild
+            >
+              {/* prefetch off + nofollow: see the hero CTA — the tracked redirect
                 must not be requested on page view or followed by crawlers. */}
-            <Link href="/get-started" prefetch={false} rel="nofollow">
-              Get started{" "}
-              <RiArrowRightSLine className="size-5 group-hover:translate-x-1 transition-transform" />
-            </Link>
-          </Button>
+              <Link href="/get-started" prefetch={false} rel="nofollow">
+                Get started{" "}
+                <RiArrowRightSLine className="size-5 group-hover:translate-x-1 transition-transform" />
+              </Link>
+            </Button>
+          </div>
+          <div className="order-1 flex items-center justify-center lg:order-2">
+            <img
+              src="/_docs.page/logo-icon.svg"
+              alt="Logo"
+              className="h-40 w-auto lg:h-60"
+            />
+          </div>
         </div>
-        <div className="order-1 flex items-center justify-center lg:order-2">
-          <img
-            src="/_docs.page/logo-icon.svg"
-            alt="Logo"
-            className="h-40 w-auto lg:h-60"
-          />
-        </div>
-      </div>
+      ) : null}
       <footer className="border-t">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4 p-6">

--- a/app/src/components/homepage/not-found.tsx
+++ b/app/src/components/homepage/not-found.tsx
@@ -1,0 +1,53 @@
+import { RiArrowRightSLine } from "@remixicon/react";
+import Head from "next/head";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { Footer } from "./footer";
+import { Header } from "./header";
+import styles from "./homepage.module.css";
+
+export function SiteNotFoundPage() {
+  return (
+    <>
+      <Head>
+        <link rel="icon" href="/_docs.page/logo-icon.svg" />
+        <title>Page Not Found | docs.page</title>
+      </Head>
+      <div
+        className={cn(
+          styles.site,
+          "dark relative min-h-svh w-full bg-black text-foreground",
+        )}
+      >
+        <div className="relative z-10 mx-auto flex min-h-svh w-full min-w-0 max-w-8xl flex-col px-0 font-mono md:px-4">
+          <div className="flex min-h-svh flex-1 flex-col md:border-x">
+            <Header />
+            <main className="flex flex-1 flex-col items-center justify-center px-6 py-16 text-center">
+              <p className="font-heading font-light text-primary text-8xl leading-none sm:text-9xl md:text-[10rem]">
+                404
+              </p>
+              <h1 className="mt-6 font-heading font-light text-3xl sm:text-4xl md:text-5xl">
+                Page Not Found
+              </h1>
+              <p className="mt-4 max-w-md text-sm font-light leading-relaxed text-neutral-400 sm:text-base">
+                Sorry, we could not find the page you are looking for.
+              </p>
+              <Button
+                asChild
+                size="lg"
+                className="mt-8 group rounded-full px-6 py-6 text-lg"
+              >
+                <Link href="/">
+                  <span>Back to docs.page</span>
+                  <RiArrowRightSLine className="size-6 group-hover:translate-x-1 transition-transform" />
+                </Link>
+              </Button>
+            </main>
+            <Footer />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/src/components/homepage/not-found.tsx
+++ b/app/src/components/homepage/not-found.tsx
@@ -3,6 +3,7 @@ import Head from "next/head";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { Background } from "./background";
 import { Footer } from "./footer";
 import { Header } from "./header";
 import styles from "./homepage.module.css";
@@ -17,9 +18,10 @@ export function SiteNotFoundPage() {
       <div
         className={cn(
           styles.site,
-          "dark relative min-h-svh w-full bg-black text-foreground",
+          "dark relative min-h-svh w-full text-foreground",
         )}
       >
+        <Background />
         <div className="relative z-10 mx-auto flex min-h-svh w-full min-w-0 max-w-8xl flex-col px-0 font-mono md:px-4">
           <div className="flex min-h-svh flex-1 flex-col md:border-x">
             <Header />
@@ -44,7 +46,7 @@ export function SiteNotFoundPage() {
                 </Link>
               </Button>
             </main>
-            <Footer />
+            <Footer showCloser={false} />
           </div>
         </div>
       </div>

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -32,6 +32,10 @@ export type HomePageProps = {
   kind: "home";
 };
 
+export type SiteNotFoundPageProps = {
+  kind: "siteNotFound";
+};
+
 export type NotFoundPageProps = {
   kind: "notFound";
   notFound: DocsNotFoundPageData;
@@ -41,5 +45,6 @@ export type PageProps =
   | DocPageProps
   | ErrorPageProps
   | NotFoundPageProps
+  | SiteNotFoundPageProps
   | RawPageProps
   | HomePageProps;

--- a/app/src/pages/404.tsx
+++ b/app/src/pages/404.tsx
@@ -1,5 +1,5 @@
-import { DocsNotFoundPage } from "@/components/docs-not-found";
+import { SiteNotFoundPage } from "@/components/homepage/not-found";
 
 export default function NotFoundPage() {
-  return <DocsNotFoundPage />;
+  return <SiteNotFoundPage />;
 }

--- a/app/src/pages/[[...path]].tsx
+++ b/app/src/pages/[[...path]].tsx
@@ -94,27 +94,32 @@ export const getServerSideProps = (async ({ params, req, res, query }) => {
     };
   }
 
+  // Single-segment paths are not valid docs routes (`/owner/repo/...`).
+  // Return `notFound: true` so Pages Router renders `pages/404.tsx` instead of
+  // the catch-all swallowing the miss with a docs-branded empty state.
   if (chunks.length === 1) {
-    res.statusCode = 404;
+    if (isDebug) {
+      res.statusCode = 404;
+
+      return {
+        props: {
+          kind: "notFound" as const,
+          notFound: {
+            debug: {
+              pathChunks: chunks,
+              error: {
+                code: 404,
+                message:
+                  "Incomplete docs route. Expected /owner/repository/...",
+              },
+            },
+          },
+        } satisfies NotFoundPageProps,
+      };
+    }
 
     return {
-      props: {
-        kind: "notFound" as const,
-        notFound: {
-          ...(isDebug
-            ? {
-                debug: {
-                  pathChunks: chunks,
-                  error: {
-                    code: 404,
-                    message:
-                      "Incomplete docs route. Expected /owner/repository/...",
-                  },
-                },
-              }
-            : {}),
-        },
-      } satisfies NotFoundPageProps,
+      notFound: true,
     };
   }
 

--- a/app/src/pages/[[...path]].tsx
+++ b/app/src/pages/[[...path]].tsx
@@ -8,6 +8,7 @@ import {
 } from "@/components/docs-debug";
 import { DocsNotFoundPage } from "@/components/docs-not-found";
 import { Homepage } from "@/components/homepage";
+import { SiteNotFoundPage } from "@/components/homepage/not-found";
 import { Preset } from "@/components/preset";
 import { DocPageContext } from "@/hooks/use-doc-page-context";
 import { getAgentPanelCookieName } from "@/lib/agent-panel-state";
@@ -36,6 +37,7 @@ import type {
   ErrorPageProps,
   NotFoundPageProps,
   PageProps,
+  SiteNotFoundPageProps,
 } from "@/lib/types";
 import { utmProperties } from "@/lib/utm";
 import {
@@ -95,12 +97,13 @@ export const getServerSideProps = (async ({ params, req, res, query }) => {
   }
 
   // Single-segment paths are not valid docs routes (`/owner/repo/...`).
-  // Return `notFound: true` so Pages Router renders `pages/404.tsx` instead of
-  // the catch-all swallowing the miss with a docs-branded empty state.
+  // Do not return `{ notFound: true }`: with a mixed App + Pages tree, Next.js
+  // 16 serves the App Router builtin 404 instead of `pages/404.tsx`. Render
+  // the site 404 from this catch-all (same pattern as docs misses) and set 404.
   if (chunks.length === 1) {
-    if (isDebug) {
-      res.statusCode = 404;
+    res.statusCode = 404;
 
+    if (isDebug) {
       return {
         props: {
           kind: "notFound" as const,
@@ -119,7 +122,9 @@ export const getServerSideProps = (async ({ params, req, res, query }) => {
     }
 
     return {
-      notFound: true,
+      props: {
+        kind: "siteNotFound" as const,
+      } satisfies SiteNotFoundPageProps,
     };
   }
 
@@ -453,6 +458,10 @@ export default function RepoDocsCatchAllPage(
 
   if (props.kind === "home") {
     return <Homepage />;
+  }
+
+  if (props.kind === "siteNotFound") {
+    return <SiteNotFoundPage />;
   }
 
   if (props.kind === "notFound") {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

First slice is a static 404 with landing chrome; shader dissolve of the 404 into the 22px spot grid comes next.

Unknown routes now render a real landing-chrome 404 instead of the docs empty state. The page reuses the homepage `Header`, `Footer` bar, and `Background` (periwinkle atmosphere), centers a honey 404 block, and uses existing landing tokens (Lexend Light, JetBrains Mono, honey pill CTA).

This does **not** add the dot-grid dissolve of the 404 number, and does not touch the feature-card sticky work on #535. Docs-site misses (`/owner/repo/...` with a missing `.mdx`) still use `DocsNotFoundPage`.

## Scope

- [x] `app/` (hosted site, MCP, Ask AI)
- [ ] `packages/cli/`
- [ ] `packages/mdx-bundler/`
- [ ] `docs/` (product documentation)
- [ ] Repo / CI / other

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan

- [x] `bun run check` passes locally
- [x] Tested locally (`bun dev`)
- [ ] Updated `docs/` (if user-facing) — N/A for this slice
- [x] Verified locally after review: 404 sits on landing periwinkle atmosphere (`Background`); closer CTA is gone; footer bar (logo, Built by Invertase, ©, Privacy, Terms) remains. Homepage Footer closer unchanged.

## Notes for reviewers

- `pages/404.tsx` holds the static page. The optional catch-all (`[[...path]].tsx`) still matches unknown URLs, so a 1-segment miss sets `res.statusCode = 404` and renders `kind: "siteNotFound"` rather than returning `{ notFound: true }`.
- In this mixed App + Pages tree, `{ notFound: true }` is served as Next.js 16’s App Router builtin 404 (`__next_builtin__not-found.js`), which is why docs misses already render from the catch-all instead of relying on `notFound: true`.
- Homepage `Footer` gained an optional `showCloser` (default `true`) so this page can drop the “Bring your docs…” closer without changing the landing page.
- `?debug` on a 1-segment path still shows the existing debug card.
- Repo docs 404s are unchanged (branding + GitHub source still go through `DocsNotFoundPage`).
- Shader dissolve of the 404 into the 22px spot grid is intentionally out of scope.

Follow-up from review: landing `Background` on the 404; closer CTA removed on this page only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfb761ba-9d4b-4017-b2ef-dcde83bf9894?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfb761ba-9d4b-4017-b2ef-dcde83bf9894&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

