### PR TITLE
fix: equalize homepage hero CTA vertical gaps

### DIFF
--- a/app/src/components/homepage/hero.tsx
+++ b/app/src/components/homepage/hero.tsx
@@ -13,25 +13,29 @@ import { UTM_KEYS } from "@/lib/utm";
 
 export function Hero() {
   return (
-    <div className="mx-auto flex w-full max-w-xl flex-col items-center justify-center space-y-6 px-2 pt-12 pb-32 sm:space-y-8 sm:px-0 sm:pt-16 sm:pb-44">
-      <Eyebrow />
-      <h1 className="flex flex-col items-center justify-center text-center font-heading text-4xl sm:text-5xl md:text-6xl">
-        <span className="font-extralight">Docs for</span>
-        <span>humans + agents</span>
-      </h1>
-      <p className="max-w-sm text-center text-sm font-light leading-relaxed text-neutral-400 sm:max-w-none sm:text-base">
-        Instantly <span className="text-primary">serve markdown</span> from any
-        GitHub branch as modern, agent-ready docs, with AI chat, MCP, and
-        llms.txt.
-      </p>
+    <div className="mx-auto flex w-full max-w-xl flex-col items-center justify-center gap-6 px-2 pt-12 pb-32 sm:px-0 sm:pt-16 sm:pb-44">
+      {/* Title block keeps the hero section rhythm (space-y-6 / sm:space-y-8).
+          The two CTA-adjacent gaps — subtext → tabs, and chip → Get started —
+          share `gap-6` so they stay equal at every width. */}
+      <div className="flex flex-col items-center space-y-6 sm:space-y-8">
+        <Eyebrow />
+        <h1 className="flex flex-col items-center justify-center text-center font-heading text-4xl sm:text-5xl md:text-6xl">
+          <span className="font-extralight">Docs for</span>
+          <span>humans + agents</span>
+        </h1>
+        <p className="max-w-sm text-center text-sm font-light leading-relaxed text-neutral-400 sm:max-w-none sm:text-base">
+          Instantly <span className="text-primary">serve markdown</span> from any
+          GitHub branch as modern, agent-ready docs, with AI chat, MCP, and
+          llms.txt.
+        </p>
+      </div>
       {/* One stacked, centred group: the snippet — its labels and the chip —
           on top, the primary action underneath, all three on the hero's axis.
           A single column at every width, so there is no `sm:flex-row` to undo
           the stack any more.
 
-          gap-6 sits on the hero's own spacing scale and stays a step tighter
-          than the space-y-8 between sections from `sm` up, which keeps the
-          action reading as part of this group rather than as another section.
+          gap-6 matches the hero stack's gap above this group, so the space
+          under the subtext and the space above Get started stay the same.
 
           w-full below `sm` so the chip still spans the hero column and shrinks
           its snippet instead of pushing past the gutter; sm:w-auto puts the

--- a/app/src/components/homepage/hero.tsx
+++ b/app/src/components/homepage/hero.tsx
@@ -24,8 +24,8 @@ export function Hero() {
           <span>humans + agents</span>
         </h1>
         <p className="max-w-sm text-center text-sm font-light leading-relaxed text-neutral-400 sm:max-w-none sm:text-base">
-          Instantly <span className="text-primary">serve markdown</span> from any
-          GitHub branch as modern, agent-ready docs, with AI chat, MCP, and
+          Instantly <span className="text-primary">serve markdown</span> from
+          any GitHub branch as modern, agent-ready docs, with AI chat, MCP, and
           llms.txt.
         </p>
       </div>

--- a/app/src/components/homepage/hero.tsx
+++ b/app/src/components/homepage/hero.tsx
@@ -13,10 +13,10 @@ import { UTM_KEYS } from "@/lib/utm";
 
 export function Hero() {
   return (
-    <div className="mx-auto flex w-full max-w-xl flex-col items-center justify-center gap-6 px-2 pt-12 pb-32 sm:px-0 sm:pt-16 sm:pb-44">
+    <div className="mx-auto flex w-full max-w-xl flex-col items-center justify-center gap-8 px-2 pt-12 pb-32 sm:px-0 sm:pt-16 sm:pb-44">
       {/* Title block keeps the hero section rhythm (space-y-6 / sm:space-y-8).
           The two CTA-adjacent gaps — subtext → tabs, and chip → Get started —
-          share `gap-6` so they stay equal at every width. */}
+          share `gap-8` so they stay equal at every width. */}
       <div className="flex flex-col items-center space-y-6 sm:space-y-8">
         <Eyebrow />
         <h1 className="flex flex-col items-center justify-center text-center font-heading text-4xl sm:text-5xl md:text-6xl">
@@ -34,13 +34,13 @@ export function Hero() {
           A single column at every width, so there is no `sm:flex-row` to undo
           the stack any more.
 
-          gap-6 matches the hero stack's gap above this group, so the space
+          gap-8 matches the hero stack's gap above this group, so the space
           under the subtext and the space above Get started stay the same.
 
           w-full below `sm` so the chip still spans the hero column and shrinks
           its snippet instead of pushing past the gutter; sm:w-auto puts the
           group back to content width. */}
-      <div className="flex w-full flex-col items-center gap-6 sm:w-auto">
+      <div className="flex w-full flex-col items-center gap-8 sm:w-auto">
         <Terminal />
         <Button
           asChild


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #540 (`feat/agent-prompt-homepage-tracking`). Do not merge before that PR.

**Railway preview (homepage):** https://docspage-docspage-pr-547.up.railway.app/

Head SHA: `aeadd7eb02b93c3f05a92997d51c8897650c0b8e`

## Summary

Georgina asked for equal vertical spacing in two places on the homepage hero, then asked both to be `gap-8` (2rem / 32px):

1. Hero subtext (…llms.txt) → “For humans | For agents” toggle
2. Prompt/URL chip → “Get started >” button

The title block (eyebrow / heading / subtext) still uses `space-y-6 sm:space-y-8`. The two CTA-adjacent gaps share `gap-8`.

Humans/agents tabs, chip, copy tracking, and Get started markup/behavior are unchanged.

## Spacing class change

| Gap | #540 | After equalize | Now |
| --- | --- | --- | --- |
| Subtext → tabs | hero `space-y-6 sm:space-y-8` (1.5rem / 2rem) | `gap-6` (1.5rem) | **`gap-8` (2rem)** |
| Chip → Get started | CTA `gap-6` (1.5rem) | `gap-6` (1.5rem) | **`gap-8` (2rem)** |

File: `app/src/components/homepage/hero.tsx`

Measured in Chrome (box edges): both gaps **32px** at 1280×900 and 390×844.

[Desktop hero, For agents — gap-8](https://cursor.com/agents/bc-6aa7e906-7e4b-4750-914c-3d856c07fc07/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhero_desktop_agents_gap8.png)
[Desktop hero, For humans — gap-8](https://cursor.com/agents/bc-6aa7e906-7e4b-4750-914c-3d856c07fc07/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhero_desktop_humans_gap8.png)
[Mobile hero, For agents — gap-8](https://cursor.com/agents/bc-6aa7e906-7e4b-4750-914c-3d856c07fc07/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhero_mobile_agents_gap8.png)

## Scope

- [x] `app/` (hosted site, MCP, Ask AI)
- [ ] `packages/cli/`
- [ ] `packages/mdx-bundler/`
- [ ] `docs/` (product documentation)
- [ ] Repo / CI / other

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan

- [x] `bun run check` passes locally
- [x] `cd app && bun run build` succeeds
- [x] Chrome box measurements: subtext→tabs = chip→button = **32px** at 1280 and 390
- [x] Updated `docs/` (if user-facing) — N/A, visual spacing only
- [x] Railway preview homepage: https://docspage-docspage-pr-547.up.railway.app/
- [x] CI on `aeadd7e`: `quality`, `test`, Railway deploy passed

## Notes for reviewers

**Depends on #540.** Base is `feat/agent-prompt-homepage-tracking`. GitHub stacking is in use.

Preview for visual check: https://docspage-docspage-pr-547.up.railway.app/

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6aa7e906-7e4b-4750-914c-3d856c07fc07?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6aa7e906-7e4b-4750-914c-3d856c07fc07&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

