### PR TITLE
feat(homepage): apply the shared feature-stage backdrop to every card

### DIFF
--- a/app/src/components/homepage/features/data.tsx
+++ b/app/src/components/homepage/features/data.tsx
@@ -14,6 +14,8 @@ export type Feature = {
   component?: ReactNode;
   /** Shared feature-stage backdrop behind the right-panel visual. */
   stage?: boolean;
+  /** Defined left copy panel (periwinkle fill + left border). */
+  copyPanel?: boolean;
 };
 
 export const features: Feature[] = [
@@ -30,6 +32,7 @@ export const features: Feature[] = [
     link: "/agent-access",
     /** First consumer of the shared feature-stage backdrop. */
     stage: true,
+    copyPanel: true,
   },
   {
     titleText: "Git Publishing",

--- a/app/src/components/homepage/features/data.tsx
+++ b/app/src/components/homepage/features/data.tsx
@@ -1,8 +1,22 @@
+import type { StaticImageData } from "next/image";
+import type { ReactNode } from "react";
 import branches from "../assets/branches-versions.png";
 import gitPublishing from "../assets/git-publishing.png";
 import { ModernInterface } from "./modern-interface";
 
-export const features = [
+export type Feature = {
+  titleText: string;
+  title: ReactNode;
+  description: string;
+  link: string;
+  video?: string;
+  image?: StaticImageData;
+  component?: ReactNode;
+  /** Shared feature-stage backdrop behind the right-panel visual. */
+  stage?: boolean;
+};
+
+export const features: Feature[] = [
   {
     titleText: "Agent-ready",
     title: (
@@ -14,6 +28,8 @@ export const features = [
       "Let users' AI agents query your documentation. Built-in MCP servers alongside llms.txt files allow LLMs to ingest your product context instantly.",
     video: "/_docs.page/agent-ready.mp4?v=2",
     link: "/agent-access",
+    /** First consumer of the shared feature-stage backdrop. */
+    stage: true,
   },
   {
     titleText: "Git Publishing",

--- a/app/src/components/homepage/features/data.tsx
+++ b/app/src/components/homepage/features/data.tsx
@@ -28,7 +28,6 @@ export const features: Feature[] = [
       "Let users' AI agents query your documentation. Built-in MCP servers alongside llms.txt files allow LLMs to ingest your product context instantly.",
     video: "/_docs.page/agent-ready.mp4?v=2",
     link: "/agent-access",
-    /** First consumer of the shared feature-stage backdrop. */
     stage: true,
   },
   {
@@ -42,6 +41,7 @@ export const features: Feature[] = [
       "Deploy updates directly from your public GitHub repository. Eliminate build pipelines, hosting configuration, or infrastructure maintenance.",
     image: gitPublishing,
     link: "/git-publishing",
+    stage: true,
   },
   {
     titleText: "Intelligent Search",
@@ -54,6 +54,7 @@ export const features: Feature[] = [
       "Index content automatically and provide an embedded AI chat. Locate information instantly without third-party tracking scripts or external setup.",
     video: "/_docs.page/intelligent-search.mp4?v=2",
     link: "/intelligent-search",
+    stage: true,
   },
   {
     titleText: "Markdown Components",
@@ -66,6 +67,7 @@ export const features: Feature[] = [
       "Add interactive components to your docs with MDX for richer experiences than standard Markdown.",
     video: "/_docs.page/markdown-components.mp4",
     link: "/markdown-components?v=2",
+    stage: true,
   },
   {
     titleText: "Branches & versions",
@@ -78,6 +80,7 @@ export const features: Feature[] = [
       "Serve any Git branch, tag, or release as a distinct documentation site. Seamlessly organise versions and live staging previews on the fly.",
     image: branches,
     link: "/agent-ready",
+    stage: true,
   },
   {
     titleText: "Modern Interface",
@@ -90,5 +93,6 @@ export const features: Feature[] = [
       "Style your docs site using shadcn/ui design standards. Customize components easily to match your brand identity.",
     component: <ModernInterface />,
     link: "/modern-interface",
+    stage: true,
   },
 ];

--- a/app/src/components/homepage/features/data.tsx
+++ b/app/src/components/homepage/features/data.tsx
@@ -14,8 +14,6 @@ export type Feature = {
   component?: ReactNode;
   /** Shared feature-stage backdrop behind the right-panel visual. */
   stage?: boolean;
-  /** Defined left copy panel (periwinkle fill + left border). */
-  copyPanel?: boolean;
 };
 
 export const features: Feature[] = [
@@ -32,7 +30,6 @@ export const features: Feature[] = [
     link: "/agent-access",
     /** First consumer of the shared feature-stage backdrop. */
     stage: true,
-    copyPanel: true,
   },
   {
     titleText: "Git Publishing",

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -28,6 +28,27 @@ export function FeatureCard({
   stage,
   children,
 }: FeatureCardProps) {
+  const copy = (
+    <>
+      <h4 className="text-2xl font-extralight font-heading text-neutral-300 lg:text-3xl">
+        {title}
+      </h4>
+      <p className="text-neutral-400 font-extralight">{description}</p>
+      <div>
+        <Button
+          variant="outline"
+          asChild
+          className="group rounded-full dark:border-primary bg-transparent font-light text-primary hover:text-primary hover:bg-primary/10"
+        >
+          <Link href={link}>
+            <span>Learn more</span>
+            <RiArrowRightSLine className="size-5 group-hover:translate-x-1 transition-transform" />
+          </Link>
+        </Button>
+      </div>
+    </>
+  );
+
   return (
     <div
       data-stack-card
@@ -35,42 +56,42 @@ export function FeatureCard({
       style={{ top: `${index}rem`, zIndex: index + 1 }}
     >
       <div
-        className={cn(PAPER_SECTION_SHELL_CLASS, "bg-black pb-20 lg:pb-40")}
+        className={cn(
+          PAPER_SECTION_SHELL_CLASS,
+          "bg-black",
+          stage
+            ? "grid grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]"
+            : "pb-20 lg:pb-40",
+        )}
         style={{ clipPath: paperCornerClipPath() }}
       >
         <PaperCorner />
-        <div className="mx-auto flex flex-col max-w-8xl space-y-8">
-          <div className="px-6 pt-8 lg:pl-26 lg:pr-0"></div>
-          <div className="mt-8 lg:mt-0 grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)] lg:gap-0">
-            <div className="flex flex-col gap-4 px-6 space-y-6 lg:mt-12 lg:px-20">
-              <h4 className="text-2xl font-extralight font-heading text-neutral-300 lg:text-3xl">
-                {title}
-              </h4>
-              <p className="text-neutral-400 font-extralight">{description}</p>
-              <div>
-                <Button
-                  variant="outline"
-                  asChild
-                  className="group rounded-full dark:border-primary bg-transparent font-light text-primary hover:text-primary hover:bg-primary/10"
-                >
-                  <Link href={link}>
-                    <span>Learn more</span>
-                    <RiArrowRightSLine className="size-5 group-hover:translate-x-1 transition-transform" />
-                  </Link>
-                </Button>
+        {stage ? (
+          <>
+            <div className="flex flex-col gap-4 space-y-6 px-6 pt-8 pb-16 lg:px-20 lg:pt-28 lg:pb-40">
+              {copy}
+            </div>
+            <div className="relative flex items-center justify-center overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10">
+              <FeatureStage>
+                <div className="px-6 py-8 lg:px-12 lg:py-12 lg:pr-20">
+                  {children}
+                </div>
+              </FeatureStage>
+            </div>
+          </>
+        ) : (
+          <div className="mx-auto flex flex-col max-w-8xl space-y-8">
+            <div className="px-6 pt-8 lg:pl-26 lg:pr-0"></div>
+            <div className="mt-8 lg:mt-0 grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)] lg:gap-0">
+              <div className="flex flex-col gap-4 px-6 space-y-6 lg:mt-12 lg:px-20">
+                {copy}
+              </div>
+              <div className="relative flex items-center justify-center px-6 pb-8 lg:pr-20 lg:px-0 lg:pb-0">
+                {children}
               </div>
             </div>
-            <div
-              className={cn(
-                "relative flex items-center justify-center px-6 pb-8 lg:pr-20 lg:px-0 lg:pb-0",
-                stage &&
-                  "overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10 px-8 pb-10 lg:px-12 lg:py-12 lg:pr-24",
-              )}
-            >
-              {stage ? <FeatureStage>{children}</FeatureStage> : children}
-            </div>
           </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -18,8 +18,6 @@ type FeatureCardProps = PropsWithChildren<{
   index: number;
   /** Shared feature-stage backdrop behind the right-panel visual. */
   stage?: boolean;
-  /** Defined left copy panel (periwinkle fill + left border). */
-  copyPanel?: boolean;
 }>;
 
 export function FeatureCard({
@@ -28,7 +26,6 @@ export function FeatureCard({
   link,
   index,
   stage,
-  copyPanel,
   children,
 }: FeatureCardProps) {
   return (
@@ -45,14 +42,7 @@ export function FeatureCard({
         <div className="mx-auto flex flex-col max-w-8xl space-y-8">
           <div className="px-6 pt-8 lg:pl-26 lg:pr-0"></div>
           <div className="mt-8 lg:mt-0 grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)] lg:gap-0">
-            <div
-              className={cn(
-                "flex flex-col gap-4 space-y-6 px-6 lg:px-20",
-                copyPanel
-                  ? "h-full justify-center border-l border-periwinkle-500 bg-periwinkle-500/10 py-8 lg:py-12"
-                  : "lg:mt-12",
-              )}
-            >
+            <div className="flex flex-col gap-4 px-6 space-y-6 lg:mt-12 lg:px-20">
               <h4 className="text-2xl font-extralight font-heading text-neutral-300 lg:text-3xl">
                 {title}
               </h4>
@@ -74,7 +64,7 @@ export function FeatureCard({
               className={cn(
                 "relative flex items-center justify-center px-6 pb-8 lg:pr-20 lg:px-0 lg:pb-0",
                 stage &&
-                  "overflow-hidden px-8 pb-10 lg:px-12 lg:py-12 lg:pr-24",
+                  "overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10 px-8 pb-10 lg:px-12 lg:py-12 lg:pr-24",
               )}
             >
               {stage ? <FeatureStage>{children}</FeatureStage> : children}

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -18,6 +18,8 @@ type FeatureCardProps = PropsWithChildren<{
   index: number;
   /** Shared feature-stage backdrop behind the right-panel visual. */
   stage?: boolean;
+  /** Defined left copy panel (periwinkle fill + left border). */
+  copyPanel?: boolean;
 }>;
 
 export function FeatureCard({
@@ -26,6 +28,7 @@ export function FeatureCard({
   link,
   index,
   stage,
+  copyPanel,
   children,
 }: FeatureCardProps) {
   return (
@@ -42,7 +45,14 @@ export function FeatureCard({
         <div className="mx-auto flex flex-col max-w-8xl space-y-8">
           <div className="px-6 pt-8 lg:pl-26 lg:pr-0"></div>
           <div className="mt-8 lg:mt-0 grid grid-cols-1 gap-8 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)] lg:gap-0">
-            <div className="flex flex-col gap-4 px-6 space-y-6 lg:mt-12 lg:px-20">
+            <div
+              className={cn(
+                "flex flex-col gap-4 space-y-6 px-6 lg:px-20",
+                copyPanel
+                  ? "h-full justify-center border-l border-periwinkle-500 bg-periwinkle-500/10 py-8 lg:py-12"
+                  : "lg:mt-12",
+              )}
+            >
               <h4 className="text-2xl font-extralight font-heading text-neutral-300 lg:text-3xl">
                 {title}
               </h4>

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -9,11 +9,6 @@ import {
   PaperCorner,
   paperCornerClipPath,
 } from "../paper-corner";
-
-/** Mobile-only dog-ear clip — must match `paperCornerClipPath()` / 5rem fold. */
-const STAGE_MOBILE_FOLD_CLIP_CLASS =
-  "max-lg:[clip-path:polygon(5rem_0,100%_0,100%_100%,0_100%,0_5rem)]";
-
 import { FeatureDotField } from "./feature-dot-field";
 
 /**
@@ -96,23 +91,19 @@ export function FeatureCard({
             </div>
             <div className="relative grid min-h-0 grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]">
               {/*
-                Mobile: extra top/left inset clears the dog-ear; extra bottom
-                pad clears the stacked media fold. Desktop L/R is unchanged;
-                copy is out of flow so height comes from media + equal inset.
+                Mobile copy matches sibling cards (px-6; pt-16 = spacer + mt-8
+                so the title clears the outer 5rem dog-ear). Desktop L/R is
+                unchanged; copy is out of flow so height comes from media.
               */}
-              <div className="flex flex-col justify-center gap-4 space-y-6 px-8 pl-24 pt-28 pb-24 lg:absolute lg:inset-y-0 lg:left-0 lg:z-1 lg:w-[calc(100%*2.5/6)] lg:px-12 lg:pl-32 lg:py-0">
+              <div className="flex flex-col justify-center gap-4 space-y-6 px-6 pt-16 pb-10 lg:absolute lg:inset-y-0 lg:left-0 lg:z-1 lg:w-[calc(100%*2.5/6)] lg:px-12 lg:pl-32 lg:py-0">
                 {copy}
               </div>
-              <div
-                className={cn(
-                  "relative min-h-0 bg-periwinkle-500/10",
-                  "max-lg:-mt-20 max-lg:overflow-hidden max-lg:border-t max-lg:border-border",
-                  STAGE_MOBILE_FOLD_CLIP_CLASS,
-                  "lg:col-start-2 lg:border-0 lg:bg-transparent",
-                )}
-              >
+              {/*
+                Mobile media is a straight-edged panel under the copy — no
+                PaperCorner, clip-path, or -mt-20 fold overlap.
+              */}
+              <div className="relative min-h-0 border-t border-border bg-periwinkle-500/10 lg:col-start-2 lg:border-0 lg:bg-transparent">
                 <div className="lg:hidden">
-                  <PaperCorner />
                   <FeatureDotField />
                 </div>
                 <div

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -59,15 +59,13 @@ export function FeatureCard({
         className={cn(
           PAPER_SECTION_SHELL_CLASS,
           "bg-black",
-          stage
-            ? "grid grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]"
-            : "pb-20 lg:pb-40",
+          !stage && "pb-20 lg:pb-40",
         )}
         style={{ clipPath: paperCornerClipPath() }}
       >
         <PaperCorner />
         {stage ? (
-          <>
+          <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]">
             <div className="flex flex-col gap-4 space-y-6 px-6 pt-8 pb-16 lg:px-20 lg:pt-28 lg:pb-40">
               {copy}
             </div>
@@ -78,7 +76,7 @@ export function FeatureCard({
                 </div>
               </FeatureStage>
             </div>
-          </>
+          </div>
         ) : (
           <div className="mx-auto flex flex-col max-w-8xl space-y-8">
             <div className="px-6 pt-8 lg:pl-26 lg:pr-0"></div>

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -101,10 +101,22 @@ export function FeatureCard({
               </div>
               {/*
                 Mobile media is a straight-edged panel under the copy — no
-                PaperCorner, clip-path, or -mt-20 fold overlap.
+                PaperCorner, clip-path, or -mt-20 fold overlap. pb-20 keeps
+                the wash / lattice / pulse above the next card’s dog-ear.
               */}
-              <div className="relative min-h-0 border-t border-border bg-periwinkle-500/10 lg:col-start-2 lg:border-0 lg:bg-transparent">
-                <div className="lg:hidden">
+              <div
+                className={cn(
+                  "relative min-h-0 border-t border-border",
+                  STAGE_STACK_CLEARANCE_CLASS,
+                  "lg:col-start-2 lg:border-0 lg:bg-transparent lg:pb-0",
+                )}
+              >
+                <div
+                  className={cn(
+                    "absolute inset-x-0 top-0 bg-periwinkle-500/10 lg:hidden",
+                    STAGE_STACK_CLEARANCE_INSET_CLASS,
+                  )}
+                >
                   <FeatureDotField />
                 </div>
                 <div

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -83,7 +83,7 @@ export function FeatureCard({
           <>
             <div
               className={cn(
-                "pointer-events-none absolute top-0 right-0 hidden overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10 lg:block lg:left-[calc(100%*2.5/6)]",
+                "pointer-events-none absolute top-0 right-0 hidden overflow-hidden border-l border-border bg-periwinkle-500/10 lg:block lg:left-[calc(100%*2.5/6)]",
                 STAGE_STACK_CLEARANCE_INSET_CLASS,
               )}
             >
@@ -97,7 +97,7 @@ export function FeatureCard({
               <div className="flex flex-col justify-center gap-4 space-y-6 px-8 py-16 lg:absolute lg:inset-y-0 lg:left-0 lg:z-1 lg:w-[calc(100%*2.5/6)] lg:px-12 lg:pl-32 lg:py-0">
                 {copy}
               </div>
-              <div className="relative min-h-0 border-l border-periwinkle-500 bg-periwinkle-500/10 lg:col-start-2 lg:border-0 lg:bg-transparent">
+              <div className="relative min-h-0 border-l border-border bg-periwinkle-500/10 lg:col-start-2 lg:border-0 lg:bg-transparent">
                 <div className="lg:hidden">
                   <FeatureDotField />
                 </div>

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -25,6 +25,11 @@ const STAGE_MEDIA_ASPECT_CLASS = "aspect-[1900/1080]";
  */
 const STAGE_STACK_CLEARANCE_CLASS = "pb-20";
 const STAGE_STACK_CLEARANCE_INSET_CLASS = "bottom-20";
+/**
+ * Mobile wash continues this far past the media box into the next card’s
+ * `-mt-20` fold so the periwinkle / lattice never hard-stop above it.
+ */
+const STAGE_MOBILE_WASH_EXTEND_CLASS = "-bottom-20";
 
 type FeatureCardProps = PropsWithChildren<{
   title: React.ReactNode;
@@ -89,7 +94,7 @@ export function FeatureCard({
             >
               <FeatureDotField />
             </div>
-            <div className="relative grid min-h-0 grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]">
+            <div className="relative grid min-h-0 overflow-visible grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]">
               {/*
                 Mobile copy matches sibling horizontal inset (px-6). pt-24
                 sits the title a rem below the outer 5rem dog-ear. Desktop
@@ -101,12 +106,12 @@ export function FeatureCard({
               </div>
               {/*
                 Mobile media is a straight-edged panel under the copy — no
-                PaperCorner, clip-path, or -mt-20 fold overlap. pb-20 keeps
-                the wash / lattice / pulse above the next card’s dog-ear.
+                PaperCorner or clip-path. Extra pb plus a fill that hangs
+                `-bottom-20` paints the wash under the next card’s fold.
               */}
               <div
                 className={cn(
-                  "relative min-h-0 border-t border-border",
+                  "relative min-h-0 overflow-visible border-t border-border",
                   STAGE_STACK_CLEARANCE_CLASS,
                   "lg:col-start-2 lg:border-0 lg:bg-transparent lg:pb-0",
                 )}
@@ -114,7 +119,7 @@ export function FeatureCard({
                 <div
                   className={cn(
                     "absolute inset-x-0 top-0 bg-periwinkle-500/10 lg:hidden",
-                    STAGE_STACK_CLEARANCE_INSET_CLASS,
+                    STAGE_MOBILE_WASH_EXTEND_CLASS,
                   )}
                 >
                   <FeatureDotField />

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -94,7 +94,7 @@ export function FeatureCard({
           <>
             <div
               className={cn(
-                "pointer-events-none absolute top-0 right-0 hidden overflow-hidden border-l border-border bg-periwinkle-500/10 lg:block lg:left-[calc(100%*2.5/6)]",
+                "pointer-events-none absolute top-0 right-0 isolate hidden overflow-hidden border-l border-border bg-periwinkle-500/10 lg:block lg:left-[calc(100%*2.5/6)]",
                 STAGE_STACK_CLEARANCE_INSET_CLASS,
               )}
             >
@@ -117,7 +117,7 @@ export function FeatureCard({
                 card’s overlapping dog-ear (no hard seam above the fold).
               */}
               <div className="relative min-h-0 overflow-visible border-t border-border lg:col-start-2 lg:border-0 lg:bg-transparent">
-                <div className="absolute inset-0 bg-periwinkle-500/10 lg:hidden">
+                <div className="absolute inset-0 isolate overflow-hidden bg-periwinkle-500/10 lg:hidden">
                   <FeatureDotField seed={index} />
                 </div>
                 <div

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -9,12 +9,15 @@ import {
   PaperCorner,
   paperCornerClipPath,
 } from "../paper-corner";
+import { FeatureDotField } from "./feature-dot-field";
 
 type FeatureCardProps = PropsWithChildren<{
   title: React.ReactNode;
   description: string;
   link: string;
   index: number;
+  /** Unkey-style periwinkle lattice + honey trail behind the visual. */
+  dotField?: boolean;
 }>;
 
 export function FeatureCard({
@@ -22,6 +25,7 @@ export function FeatureCard({
   description,
   link,
   index,
+  dotField,
   children,
 }: FeatureCardProps) {
   return (
@@ -56,8 +60,19 @@ export function FeatureCard({
                 </Button>
               </div>
             </div>
-            <div className="relative flex items-center justify-center px-6 pb-8 lg:pr-20 lg:px-0 lg:pb-0">
-              {children}
+            <div
+              className={cn(
+                "relative flex items-center justify-center px-6 pb-8 lg:pr-20 lg:px-0 lg:pb-0",
+                dotField &&
+                  "overflow-hidden px-8 pb-10 lg:px-12 lg:py-12 lg:pr-24",
+              )}
+            >
+              {dotField ? <FeatureDotField /> : null}
+              {dotField ? (
+                <div className="relative z-1 w-full">{children}</div>
+              ) : (
+                children
+              )}
             </div>
           </div>
         </div>

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -17,7 +17,11 @@ import { FeatureDotField } from "./feature-dot-field";
  * (no leftover column letterbox, no clip against the card).
  */
 const STAGE_MEDIA_INSET_CLASS = "p-8 lg:p-12";
-/** Agent-ready capture is 1900×1080; keep the inner box matching so contain === cover. */
+/**
+ * Feature videos are 1900×1080 (search/markdown are 1904×1080). Keep the
+ * inner box matching so contain ≈ cover for video. Wider stills letterbox
+ * into the periwinkle wash rather than cropping.
+ */
 const STAGE_MEDIA_ASPECT_CLASS = "aspect-[1900/1080]";
 /**
  * Next paper card uses `-mt-20` (the dog-ear fold). Desktop fill pins to
@@ -123,8 +127,10 @@ export function FeatureCard({
                     className={cn(
                       "relative w-full min-w-0",
                       STAGE_MEDIA_ASPECT_CLASS,
-                      "[&_img]:absolute [&_img]:inset-0 [&_img]:size-full [&_img]:object-contain",
-                      "[&_video]:absolute [&_video]:inset-0 [&_video]:size-full [&_video]:object-contain",
+                      // Direct FeatureMedia children only — do not pierce
+                      // composite visuals (Modern Interface preset shots).
+                      "[&>*>img]:absolute [&>*>img]:inset-0 [&>*>img]:size-full [&>*>img]:object-contain",
+                      "[&>*>video]:absolute [&>*>video]:inset-0 [&>*>video]:size-full [&>*>video]:object-contain",
                     )}
                   >
                     {children}

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -9,7 +9,7 @@ import {
   PaperCorner,
   paperCornerClipPath,
 } from "../paper-corner";
-import { FeatureStage } from "./feature-dot-field";
+import { FeatureDotField } from "./feature-dot-field";
 
 type FeatureCardProps = PropsWithChildren<{
   title: React.ReactNode;
@@ -66,20 +66,20 @@ export function FeatureCard({
         <PaperCorner />
         {stage ? (
           <>
-            <div
-              aria-hidden
-              className="pointer-events-none absolute inset-y-0 right-0 hidden border-l border-periwinkle-500 bg-periwinkle-500/10 lg:block lg:left-[calc(100%*2.5/6)]"
-            />
+            <div className="pointer-events-none absolute inset-y-0 right-0 hidden overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10 lg:block lg:left-[calc(100%*2.5/6)]">
+              <FeatureDotField />
+            </div>
             <div className="relative grid grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]">
               <div className="flex flex-col gap-4 space-y-6 px-6 pt-8 pb-16 lg:px-20 lg:pt-28 lg:pb-40">
                 {copy}
               </div>
               <div className="relative flex items-center justify-center overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10 lg:border-0 lg:bg-transparent">
-                <FeatureStage>
-                  <div className="px-6 py-8 lg:px-12 lg:py-12 lg:pr-20">
-                    {children}
-                  </div>
-                </FeatureStage>
+                <div className="lg:hidden">
+                  <FeatureDotField />
+                </div>
+                <div className="relative z-1 w-full px-6 py-8 lg:px-12 lg:py-12 lg:pr-20">
+                  {children}
+                </div>
               </div>
             </div>
           </>

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -19,6 +19,12 @@ import { FeatureDotField } from "./feature-dot-field";
 const STAGE_MEDIA_INSET_CLASS = "p-8 lg:p-12";
 /** Agent-ready capture is 1900×1080; keep the inner box matching so contain === cover. */
 const STAGE_MEDIA_ASPECT_CLASS = "aspect-[1900/1080]";
+/**
+ * Next paper card uses `-mt-20` (the dog-ear fold). Staged cards must clear that
+ * overlap or the fill, divider, and bottom media inset sit under the next card.
+ */
+const STAGE_STACK_CLEARANCE_CLASS = "pb-20";
+const STAGE_STACK_CLEARANCE_INSET_CLASS = "bottom-20";
 
 type FeatureCardProps = PropsWithChildren<{
   title: React.ReactNode;
@@ -68,14 +74,19 @@ export function FeatureCard({
         className={cn(
           PAPER_SECTION_SHELL_CLASS,
           "bg-black",
-          !stage && "pb-20 lg:pb-40",
+          stage ? STAGE_STACK_CLEARANCE_CLASS : "pb-20 lg:pb-40",
         )}
         style={{ clipPath: paperCornerClipPath() }}
       >
         <PaperCorner />
         {stage ? (
           <>
-            <div className="pointer-events-none absolute inset-y-0 right-0 hidden overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10 lg:block lg:left-[calc(100%*2.5/6)]">
+            <div
+              className={cn(
+                "pointer-events-none absolute top-0 right-0 hidden overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10 lg:block lg:left-[calc(100%*2.5/6)]",
+                STAGE_STACK_CLEARANCE_INSET_CLASS,
+              )}
+            >
               <FeatureDotField />
             </div>
             <div className="relative grid min-h-0 grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]">
@@ -86,7 +97,7 @@ export function FeatureCard({
               <div className="flex flex-col justify-center gap-4 space-y-6 px-8 py-16 lg:absolute lg:inset-y-0 lg:left-0 lg:z-1 lg:w-[calc(100%*2.5/6)] lg:px-12 lg:pl-32 lg:py-0">
                 {copy}
               </div>
-              <div className="relative min-h-0 overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10 lg:col-start-2 lg:border-0 lg:bg-transparent">
+              <div className="relative min-h-0 border-l border-periwinkle-500 bg-periwinkle-500/10 lg:col-start-2 lg:border-0 lg:bg-transparent">
                 <div className="lg:hidden">
                   <FeatureDotField />
                 </div>

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -27,10 +27,11 @@ const STAGE_MEDIA_ASPECT_CLASS = "aspect-[1900/1080]";
 const STAGE_STACK_CLEARANCE_CLASS = "lg:pb-20";
 const STAGE_STACK_CLEARANCE_INSET_CLASS = "bottom-20";
 /**
- * In-flow mobile spacer below the visual. Taller than the next card’s
- * `-mt-20` fold so the inset-0 wash runs under Git Publishing (no black seam).
+ * In-flow mobile spacer below the visual. Just over the next card’s
+ * `-mt-20` fold (5rem) so the inset-0 wash still runs under Git Publishing
+ * without a large empty gap.
  */
-const STAGE_MOBILE_WASH_PAD_CLASS = "h-40";
+const STAGE_MOBILE_WASH_PAD_CLASS = "h-24";
 
 type FeatureCardProps = PropsWithChildren<{
   title: React.ReactNode;

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -36,14 +36,6 @@ const STAGE_STACK_CLEARANCE_INSET_CLASS = "bottom-20";
  * without a large empty gap.
  */
 const STAGE_MOBILE_WASH_PAD_CLASS = "h-24";
-/**
- * Soft lift along the top fold so stacked cards read as separate layers
- * (wash still runs under the next dog-ear). Applied on a sibling caster —
- * clip-path eats box-shadow, and filtering the shell would re-rasterize
- * the honey canvas every frame.
- */
-const STAGE_STACK_LIFT_FILTER =
-  "drop-shadow(0 -1px 2px rgb(0 0 0 / 0.7)) drop-shadow(0 -8px 14px rgb(0 0 0 / 0.45))";
 
 type FeatureCardProps = PropsWithChildren<{
   title: React.ReactNode;
@@ -86,19 +78,9 @@ export function FeatureCard({
   return (
     <div
       data-stack-card
-      className={cn(PAPER_SECTION_OVERLAP_CLASS, "relative sticky")}
+      className={cn(PAPER_SECTION_OVERLAP_CLASS, "sticky")}
       style={{ top: `${index}rem`, zIndex: index + 1 }}
     >
-      <div
-        aria-hidden
-        className="pointer-events-none absolute inset-0 -z-10"
-        style={{ filter: STAGE_STACK_LIFT_FILTER }}
-      >
-        <div
-          className="absolute inset-0 bg-black"
-          style={{ clipPath: paperCornerClipPath() }}
-        />
-      </div>
       <div
         className={cn(
           PAPER_SECTION_SHELL_CLASS,

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -9,6 +9,11 @@ import {
   PaperCorner,
   paperCornerClipPath,
 } from "../paper-corner";
+
+/** Mobile-only dog-ear clip — must match `paperCornerClipPath()` / 5rem fold. */
+const STAGE_MOBILE_FOLD_CLIP_CLASS =
+  "max-lg:[clip-path:polygon(5rem_0,100%_0,100%_100%,0_100%,0_5rem)]";
+
 import { FeatureDotField } from "./feature-dot-field";
 
 /**
@@ -91,14 +96,23 @@ export function FeatureCard({
             </div>
             <div className="relative grid min-h-0 grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]">
               {/*
-                L/R copy inset is unchanged. On desktop the copy is out of flow so
-                its py cannot stretch the row — height comes from media + equal inset.
+                Mobile: extra top/left inset clears the dog-ear; extra bottom
+                pad clears the stacked media fold. Desktop L/R is unchanged;
+                copy is out of flow so height comes from media + equal inset.
               */}
-              <div className="flex flex-col justify-center gap-4 space-y-6 px-8 py-16 lg:absolute lg:inset-y-0 lg:left-0 lg:z-1 lg:w-[calc(100%*2.5/6)] lg:px-12 lg:pl-32 lg:py-0">
+              <div className="flex flex-col justify-center gap-4 space-y-6 px-8 pl-24 pt-28 pb-24 lg:absolute lg:inset-y-0 lg:left-0 lg:z-1 lg:w-[calc(100%*2.5/6)] lg:px-12 lg:pl-32 lg:py-0">
                 {copy}
               </div>
-              <div className="relative min-h-0 border-l border-border bg-periwinkle-500/10 lg:col-start-2 lg:border-0 lg:bg-transparent">
+              <div
+                className={cn(
+                  "relative min-h-0 bg-periwinkle-500/10",
+                  "max-lg:-mt-20 max-lg:overflow-hidden max-lg:border-t max-lg:border-border",
+                  STAGE_MOBILE_FOLD_CLIP_CLASS,
+                  "lg:col-start-2 lg:border-0 lg:bg-transparent",
+                )}
+              >
                 <div className="lg:hidden">
+                  <PaperCorner />
                   <FeatureDotField />
                 </div>
                 <div

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -36,6 +36,14 @@ const STAGE_STACK_CLEARANCE_INSET_CLASS = "bottom-20";
  * without a large empty gap.
  */
 const STAGE_MOBILE_WASH_PAD_CLASS = "h-24";
+/**
+ * Soft lift along the top fold so stacked cards read as separate layers
+ * (wash still runs under the next dog-ear). Applied on a sibling caster —
+ * clip-path eats box-shadow, and filtering the shell would re-rasterize
+ * the honey canvas every frame.
+ */
+const STAGE_STACK_LIFT_FILTER =
+  "drop-shadow(0 -1px 2px rgb(0 0 0 / 0.7)) drop-shadow(0 -8px 14px rgb(0 0 0 / 0.45))";
 
 type FeatureCardProps = PropsWithChildren<{
   title: React.ReactNode;
@@ -78,9 +86,19 @@ export function FeatureCard({
   return (
     <div
       data-stack-card
-      className={cn(PAPER_SECTION_OVERLAP_CLASS, "sticky")}
+      className={cn(PAPER_SECTION_OVERLAP_CLASS, "relative sticky")}
       style={{ top: `${index}rem`, zIndex: index + 1 }}
     >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 -z-10"
+        style={{ filter: STAGE_STACK_LIFT_FILTER }}
+      >
+        <div
+          className="absolute inset-0 bg-black"
+          style={{ clipPath: paperCornerClipPath() }}
+        />
+      </div>
       <div
         className={cn(
           PAPER_SECTION_SHELL_CLASS,
@@ -98,7 +116,7 @@ export function FeatureCard({
                 STAGE_STACK_CLEARANCE_INSET_CLASS,
               )}
             >
-              <FeatureDotField />
+              <FeatureDotField seed={index} />
             </div>
             <div className="relative grid min-h-0 overflow-visible grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]">
               {/*
@@ -118,7 +136,7 @@ export function FeatureCard({
               */}
               <div className="relative min-h-0 overflow-visible border-t border-border lg:col-start-2 lg:border-0 lg:bg-transparent">
                 <div className="absolute inset-0 bg-periwinkle-500/10 lg:hidden">
-                  <FeatureDotField />
+                  <FeatureDotField seed={index} />
                 </div>
                 <div
                   className={cn("relative z-1 w-full", STAGE_MEDIA_INSET_CLASS)}

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -91,11 +91,12 @@ export function FeatureCard({
             </div>
             <div className="relative grid min-h-0 grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]">
               {/*
-                Mobile copy matches sibling cards (px-6; pt-16 = spacer + mt-8
-                so the title clears the outer 5rem dog-ear). Desktop L/R is
-                unchanged; copy is out of flow so height comes from media.
+                Mobile copy matches sibling horizontal inset (px-6). pt-24
+                sits the title a rem below the outer 5rem dog-ear. Desktop
+                L/R is unchanged; copy is out of flow so height comes from
+                media.
               */}
-              <div className="flex flex-col justify-center gap-4 space-y-6 px-6 pt-16 pb-10 lg:absolute lg:inset-y-0 lg:left-0 lg:z-1 lg:w-[calc(100%*2.5/6)] lg:px-12 lg:pl-32 lg:py-0">
+              <div className="flex flex-col justify-center gap-4 space-y-6 px-6 pt-24 pb-10 lg:absolute lg:inset-y-0 lg:left-0 lg:z-1 lg:w-[calc(100%*2.5/6)] lg:px-12 lg:pl-32 lg:py-0">
                 {copy}
               </div>
               {/*

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -65,18 +65,24 @@ export function FeatureCard({
       >
         <PaperCorner />
         {stage ? (
-          <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]">
-            <div className="flex flex-col gap-4 space-y-6 px-6 pt-8 pb-16 lg:px-20 lg:pt-28 lg:pb-40">
-              {copy}
+          <>
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-y-0 right-0 hidden border-l border-periwinkle-500 bg-periwinkle-500/10 lg:block lg:left-[calc(100%*2.5/6)]"
+            />
+            <div className="relative grid grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]">
+              <div className="flex flex-col gap-4 space-y-6 px-6 pt-8 pb-16 lg:px-20 lg:pt-28 lg:pb-40">
+                {copy}
+              </div>
+              <div className="relative flex items-center justify-center overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10 lg:border-0 lg:bg-transparent">
+                <FeatureStage>
+                  <div className="px-6 py-8 lg:px-12 lg:py-12 lg:pr-20">
+                    {children}
+                  </div>
+                </FeatureStage>
+              </div>
             </div>
-            <div className="relative flex items-center justify-center overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10">
-              <FeatureStage>
-                <div className="px-6 py-8 lg:px-12 lg:py-12 lg:pr-20">
-                  {children}
-                </div>
-              </FeatureStage>
-            </div>
-          </div>
+          </>
         ) : (
           <div className="mx-auto flex flex-col max-w-8xl space-y-8">
             <div className="px-6 pt-8 lg:pl-26 lg:pr-0"></div>

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -9,15 +9,15 @@ import {
   PaperCorner,
   paperCornerClipPath,
 } from "../paper-corner";
-import { FeatureDotField } from "./feature-dot-field";
+import { FeatureStage } from "./feature-dot-field";
 
 type FeatureCardProps = PropsWithChildren<{
   title: React.ReactNode;
   description: string;
   link: string;
   index: number;
-  /** Unkey-style periwinkle lattice + honey trail behind the visual. */
-  dotField?: boolean;
+  /** Shared feature-stage backdrop behind the right-panel visual. */
+  stage?: boolean;
 }>;
 
 export function FeatureCard({
@@ -25,7 +25,7 @@ export function FeatureCard({
   description,
   link,
   index,
-  dotField,
+  stage,
   children,
 }: FeatureCardProps) {
   return (
@@ -63,16 +63,11 @@ export function FeatureCard({
             <div
               className={cn(
                 "relative flex items-center justify-center px-6 pb-8 lg:pr-20 lg:px-0 lg:pb-0",
-                dotField &&
+                stage &&
                   "overflow-hidden px-8 pb-10 lg:px-12 lg:py-12 lg:pr-24",
               )}
             >
-              {dotField ? <FeatureDotField /> : null}
-              {dotField ? (
-                <div className="relative z-1 w-full">{children}</div>
-              ) : (
-                children
-              )}
+              {stage ? <FeatureStage>{children}</FeatureStage> : children}
             </div>
           </div>
         </div>

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -11,6 +11,15 @@ import {
 } from "../paper-corner";
 import { FeatureDotField } from "./feature-dot-field";
 
+/**
+ * Equal inset around staged media — same token on all four sides.
+ * Pair with the 1900×1080 aspect box so the visual fills the inner rectangle
+ * (no leftover column letterbox, no clip against the card).
+ */
+const STAGE_MEDIA_INSET_CLASS = "p-8 lg:p-12";
+/** Agent-ready capture is 1900×1080; keep the inner box matching so contain === cover. */
+const STAGE_MEDIA_ASPECT_CLASS = "aspect-[1900/1080]";
+
 type FeatureCardProps = PropsWithChildren<{
   title: React.ReactNode;
   description: string;
@@ -70,15 +79,30 @@ export function FeatureCard({
               <FeatureDotField />
             </div>
             <div className="relative grid min-h-0 grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]">
-              <div className="flex flex-col justify-center gap-4 space-y-6 px-8 py-16 lg:px-12 lg:pl-32 lg:py-28">
+              {/*
+                L/R copy inset is unchanged. On desktop the copy is out of flow so
+                its py cannot stretch the row — height comes from media + equal inset.
+              */}
+              <div className="flex flex-col justify-center gap-4 space-y-6 px-8 py-16 lg:absolute lg:inset-y-0 lg:left-0 lg:z-1 lg:w-[calc(100%*2.5/6)] lg:px-12 lg:pl-32 lg:py-0">
                 {copy}
               </div>
-              <div className="relative flex min-h-0 items-center justify-center overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10 lg:border-0 lg:bg-transparent">
+              <div className="relative min-h-0 overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10 lg:col-start-2 lg:border-0 lg:bg-transparent">
                 <div className="lg:hidden">
                   <FeatureDotField />
                 </div>
-                <div className="relative z-1 flex size-full min-h-0 items-center justify-center p-8 lg:p-12 [&_img]:max-h-full [&_video]:max-h-full [&_video]:object-contain">
-                  {children}
+                <div
+                  className={cn("relative z-1 w-full", STAGE_MEDIA_INSET_CLASS)}
+                >
+                  <div
+                    className={cn(
+                      "relative w-full min-w-0",
+                      STAGE_MEDIA_ASPECT_CLASS,
+                      "[&_img]:absolute [&_img]:inset-0 [&_img]:size-full [&_img]:object-contain",
+                      "[&_video]:absolute [&_video]:inset-0 [&_video]:size-full [&_video]:object-contain",
+                    )}
+                  >
+                    {children}
+                  </div>
                 </div>
               </div>
             </div>

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -26,8 +26,11 @@ const STAGE_MEDIA_ASPECT_CLASS = "aspect-[1900/1080]";
  */
 const STAGE_STACK_CLEARANCE_CLASS = "lg:pb-20";
 const STAGE_STACK_CLEARANCE_INSET_CLASS = "bottom-20";
-/** Extra mobile stage height below the visual; wash fills this (not a black gap). */
-const STAGE_MOBILE_WASH_PAD_CLASS = "pb-32";
+/**
+ * In-flow mobile spacer below the visual. Taller than the next card’s
+ * `-mt-20` fold so the inset-0 wash runs under Git Publishing (no black seam).
+ */
+const STAGE_MOBILE_WASH_PAD_CLASS = "h-40";
 
 type FeatureCardProps = PropsWithChildren<{
   title: React.ReactNode;
@@ -108,13 +111,7 @@ export function FeatureCard({
                 lattice / pulse run through the extra pb and under the next
                 card’s overlapping dog-ear (no hard seam above the fold).
               */}
-              <div
-                className={cn(
-                  "relative min-h-0 overflow-visible border-t border-border",
-                  STAGE_MOBILE_WASH_PAD_CLASS,
-                  "lg:col-start-2 lg:border-0 lg:bg-transparent lg:pb-0",
-                )}
-              >
+              <div className="relative min-h-0 overflow-visible border-t border-border lg:col-start-2 lg:border-0 lg:bg-transparent">
                 <div className="absolute inset-0 bg-periwinkle-500/10 lg:hidden">
                   <FeatureDotField />
                 </div>
@@ -132,6 +129,10 @@ export function FeatureCard({
                     {children}
                   </div>
                 </div>
+                <div
+                  className={cn(STAGE_MOBILE_WASH_PAD_CLASS, "lg:hidden")}
+                  aria-hidden
+                />
               </div>
             </div>
           </>

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -69,15 +69,15 @@ export function FeatureCard({
             <div className="pointer-events-none absolute inset-y-0 right-0 hidden overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10 lg:block lg:left-[calc(100%*2.5/6)]">
               <FeatureDotField />
             </div>
-            <div className="relative grid grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]">
-              <div className="flex flex-col gap-4 space-y-6 px-6 pt-8 pb-16 lg:px-20 lg:pt-28 lg:pb-40">
+            <div className="relative grid min-h-0 grid-cols-1 lg:grid-cols-[minmax(0,2.5fr)_minmax(0,3.5fr)]">
+              <div className="flex flex-col justify-center gap-4 space-y-6 px-8 py-16 lg:px-12 lg:pl-32 lg:py-28">
                 {copy}
               </div>
-              <div className="relative flex items-center justify-center overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10 lg:border-0 lg:bg-transparent">
+              <div className="relative flex min-h-0 items-center justify-center overflow-hidden border-l border-periwinkle-500 bg-periwinkle-500/10 lg:border-0 lg:bg-transparent">
                 <div className="lg:hidden">
                   <FeatureDotField />
                 </div>
-                <div className="relative z-1 w-full px-6 py-8 lg:px-12 lg:py-12 lg:pr-20">
+                <div className="relative z-1 flex size-full min-h-0 items-center justify-center p-8 lg:p-12 [&_img]:max-h-full [&_video]:max-h-full [&_video]:object-contain">
                   {children}
                 </div>
               </div>

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import type { PropsWithChildren } from "react";
 import { cn } from "@/lib/utils";
 import { Button } from "../../ui/button";
+import styles from "../homepage.module.css";
 import {
   PAPER_SECTION_OVERLAP_CLASS,
   PAPER_SECTION_SHELL_CLASS,
@@ -36,6 +37,8 @@ const STAGE_STACK_CLEARANCE_INSET_CLASS = "bottom-20";
  * without a large empty gap.
  */
 const STAGE_MOBILE_WASH_PAD_CLASS = "h-24";
+/** Shared radial periwinkle wash — desktop column + mobile media panel. */
+const STAGE_WASH_CLASS = styles["homepage-feature-stage-wash"];
 
 type FeatureCardProps = PropsWithChildren<{
   title: React.ReactNode;
@@ -94,7 +97,8 @@ export function FeatureCard({
           <>
             <div
               className={cn(
-                "pointer-events-none absolute top-0 right-0 isolate hidden overflow-hidden border-l border-border bg-periwinkle-500/10 lg:block lg:left-[calc(100%*2.5/6)]",
+                "pointer-events-none absolute top-0 right-0 isolate hidden overflow-hidden border-l border-border lg:block lg:left-[calc(100%*2.5/6)]",
+                STAGE_WASH_CLASS,
                 STAGE_STACK_CLEARANCE_INSET_CLASS,
               )}
             >
@@ -117,7 +121,12 @@ export function FeatureCard({
                 card’s overlapping dog-ear (no hard seam above the fold).
               */}
               <div className="relative min-h-0 overflow-visible border-t border-border lg:col-start-2 lg:border-0 lg:bg-transparent">
-                <div className="absolute inset-0 isolate overflow-hidden bg-periwinkle-500/10 lg:hidden">
+                <div
+                  className={cn(
+                    "absolute inset-0 isolate overflow-hidden lg:hidden",
+                    STAGE_WASH_CLASS,
+                  )}
+                >
                   <FeatureDotField seed={index} />
                 </div>
                 <div

--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -20,16 +20,14 @@ const STAGE_MEDIA_INSET_CLASS = "p-8 lg:p-12";
 /** Agent-ready capture is 1900×1080; keep the inner box matching so contain === cover. */
 const STAGE_MEDIA_ASPECT_CLASS = "aspect-[1900/1080]";
 /**
- * Next paper card uses `-mt-20` (the dog-ear fold). Staged cards must clear that
- * overlap or the fill, divider, and bottom media inset sit under the next card.
+ * Next paper card uses `-mt-20` (the dog-ear fold). Desktop fill pins to
+ * `bottom-20` so the right-column wash meets that seam. Mobile leaves the
+ * shell unpadded so the stage wash can run to the card edge and under the fold.
  */
-const STAGE_STACK_CLEARANCE_CLASS = "pb-20";
+const STAGE_STACK_CLEARANCE_CLASS = "lg:pb-20";
 const STAGE_STACK_CLEARANCE_INSET_CLASS = "bottom-20";
-/**
- * Mobile wash continues this far past the media box into the next card’s
- * `-mt-20` fold so the periwinkle / lattice never hard-stop above it.
- */
-const STAGE_MOBILE_WASH_EXTEND_CLASS = "-bottom-20";
+/** Extra mobile stage height below the visual; wash fills this (not a black gap). */
+const STAGE_MOBILE_WASH_PAD_CLASS = "pb-32";
 
 type FeatureCardProps = PropsWithChildren<{
   title: React.ReactNode;
@@ -106,22 +104,18 @@ export function FeatureCard({
               </div>
               {/*
                 Mobile media is a straight-edged panel under the copy — no
-                PaperCorner or clip-path. Extra pb plus a fill that hangs
-                `-bottom-20` paints the wash under the next card’s fold.
+                PaperCorner or clip-path. The fill is inset-0 so wash /
+                lattice / pulse run through the extra pb and under the next
+                card’s overlapping dog-ear (no hard seam above the fold).
               */}
               <div
                 className={cn(
                   "relative min-h-0 overflow-visible border-t border-border",
-                  STAGE_STACK_CLEARANCE_CLASS,
+                  STAGE_MOBILE_WASH_PAD_CLASS,
                   "lg:col-start-2 lg:border-0 lg:bg-transparent lg:pb-0",
                 )}
               >
-                <div
-                  className={cn(
-                    "absolute inset-x-0 top-0 bg-periwinkle-500/10 lg:hidden",
-                    STAGE_MOBILE_WASH_EXTEND_CLASS,
-                  )}
-                >
+                <div className="absolute inset-0 bg-periwinkle-500/10 lg:hidden">
                   <FeatureDotField />
                 </div>
                 <div

--- a/app/src/components/homepage/features/feature-dot-field.tsx
+++ b/app/src/components/homepage/features/feature-dot-field.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { type CSSProperties, useEffect, useRef } from "react";
+import {
+  type CSSProperties,
+  type PropsWithChildren,
+  useEffect,
+  useRef,
+} from "react";
 import { cn } from "@/lib/utils";
 import styles from "../homepage.module.css";
 
@@ -73,12 +78,20 @@ function drawDot(
   ctx.fill();
 }
 
+export type FeatureDotFieldProps = {
+  /** Extra classes on the absolute-fill wrapper. */
+  className?: string;
+};
+
 /**
- * Periwinkle lattice (reuses `homepage-spot-grid-card`) plus a short honey
- * trail that walks the grid horizontally and vertically. Frozen when the
- * user prefers reduced motion.
+ * Shared feature-stage backdrop: periwinkle lattice (reuses
+ * `homepage-spot-grid-card`) plus a short honey trail that walks the grid
+ * horizontally and vertically. Frozen when the user prefers reduced motion.
+ *
+ * Positioned `absolute inset-0` — drop behind any feature visual. Prefer
+ * {@link FeatureStage} when you also need the stacking wrapper.
  */
-export function FeatureDotField({ className }: { className?: string }) {
+export function FeatureDotField({ className }: FeatureDotFieldProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
@@ -205,5 +218,23 @@ export function FeatureDotField({ className }: { className?: string }) {
       />
       <canvas ref={canvasRef} className="absolute inset-0" />
     </div>
+  );
+}
+
+export type FeatureStageProps = PropsWithChildren<{
+  className?: string;
+}>;
+
+/**
+ * Right-panel feature stage: lattice + honey trail behind a floating visual.
+ * Parent must be `position: relative`. Later feature-visual PRs wrap their
+ * media in this — do not fork the trail.
+ */
+export function FeatureStage({ children, className }: FeatureStageProps) {
+  return (
+    <>
+      <FeatureDotField className={className} />
+      <div className="relative z-1 w-full">{children}</div>
+    </>
   );
 }

--- a/app/src/components/homepage/features/feature-dot-field.tsx
+++ b/app/src/components/homepage/features/feature-dot-field.tsx
@@ -16,8 +16,8 @@ const CELL = 22;
  */
 const EDGE = 2;
 /** Travelling bloom width, in cells. */
-const PULSE_SIGMA = 2.8;
-const CELLS_PER_SEC = 4;
+const PULSE_SIGMA = 2.1;
+const CELLS_PER_SEC = 8;
 /** Honey `#E69135` — brand token, not a new colour. */
 const HONEY_RGB = "230, 145, 53";
 
@@ -152,9 +152,9 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
           if (b < 0.04) continue;
           const gx = run.horizontal ? i : axis;
           const gy = run.horizontal ? axis : i;
-          const r = 2.4 + b * 2.2;
-          const a = 0.4 + b * 0.6;
-          drawDot(ctx, rect.left, rect.top, gx, gy, r * 2.1, a * 0.28);
+          const r = 1.2 + b * 0.55;
+          const a = 0.22 + b * 0.5;
+          drawDot(ctx, rect.left, rect.top, gx, gy, r * 1.55, a * 0.16);
           drawDot(ctx, rect.left, rect.top, gx, gy, r, a);
         }
       }
@@ -163,7 +163,7 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
     const paintRest = (now: number) => {
       const { rect } = bounds(root);
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      const pulse = 0.45 + 0.4 * (0.5 + 0.5 * Math.sin(now / 900));
+      const pulse = 0.28 + 0.28 * (0.5 + 0.5 * Math.sin(now / 900));
       const mid = ((run.from + run.to) / 2) | 0;
       for (let depth = 0; depth < EDGE; depth++) {
         const axis = run.axis0 + run.inward * depth;
@@ -171,8 +171,8 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
           if (i < run.from || i > run.to) continue;
           const gx = run.horizontal ? i : axis;
           const gy = run.horizontal ? axis : i;
-          drawDot(ctx, rect.left, rect.top, gx, gy, 3.2, pulse * 0.3);
-          drawDot(ctx, rect.left, rect.top, gx, gy, 2.6, pulse);
+          drawDot(ctx, rect.left, rect.top, gx, gy, 2.1, pulse * 0.18);
+          drawDot(ctx, rect.left, rect.top, gx, gy, 1.5, pulse);
         }
       }
     };

--- a/app/src/components/homepage/features/feature-dot-field.tsx
+++ b/app/src/components/homepage/features/feature-dot-field.tsx
@@ -149,18 +149,6 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
           drawDot(ctx, rect.left, rect.top, gx, gy, r * 1.55, a * 0.16);
           drawDot(ctx, rect.left, rect.top, gx, gy, r, a);
         }
-        const gx = run.horizontal ? head : axis;
-        const gy = run.horizontal ? axis : head;
-        const peak = falloff;
-        drawDot(
-          ctx,
-          rect.left,
-          rect.top,
-          gx,
-          gy,
-          1.2 + 0.55 * peak,
-          (0.22 + 0.5 * peak) * 0.7,
-        );
       }
     };
 

--- a/app/src/components/homepage/features/feature-dot-field.tsx
+++ b/app/src/components/homepage/features/feature-dot-field.tsx
@@ -15,8 +15,8 @@ const CELL = 22;
  * both rings of the active side light so the wash reads at a glance.
  */
 const EDGE = 2;
-/** Travelling bloom width, in cells. */
-const PULSE_SIGMA = 2.1;
+/** Travelling bloom width, in cells — wide enough to blend, not orb-sized. */
+const PULSE_SIGMA = 2.45;
 const CELLS_PER_SEC = 8;
 /** Honey `#E69135` — brand token, not a new colour. */
 const HONEY_RGB = "230, 145, 53";
@@ -67,11 +67,13 @@ function bounds(el: HTMLElement) {
   return { rect, minX, minY, maxX, maxY };
 }
 
-function pickRun(el: HTMLElement, horizontal: boolean): Run {
+function pickRun(el: HTMLElement, horizontal: boolean, avoid?: Run): Run {
   const { minX, minY, maxX, maxY } = bounds(el);
   const dir: 1 | -1 = Math.random() < 0.5 ? 1 : -1;
+  const flip = avoid && avoid.horizontal === horizontal;
   if (horizontal) {
-    const top = Math.random() < 0.5;
+    let top = Math.random() < 0.5;
+    if (flip && avoid) top = avoid.axis0 !== minY;
     return {
       horizontal,
       axis0: top ? minY : maxY,
@@ -82,7 +84,8 @@ function pickRun(el: HTMLElement, horizontal: boolean): Run {
       start: dir === 1 ? minX : maxX,
     };
   }
-  const left = Math.random() < 0.5;
+  let left = Math.random() < 0.5;
+  if (flip && avoid) left = avoid.axis0 !== minX;
   return {
     horizontal,
     axis0: left ? minX : maxX,
@@ -104,8 +107,8 @@ export type FeatureDotFieldProps = {
 };
 
 /**
- * Shared feature-stage backdrop: the homepage spot-grid plus honey dots that
- * pulse along one horizontal or vertical rim strip (both EDGE rings).
+ * Shared feature-stage backdrop: the homepage spot-grid plus two honey
+ * blooms that pulse along rim strips (one H, one V; both EDGE rings).
  * `prefers-reduced-motion` keeps a gentle in-place pulse.
  *
  * Positioned `absolute inset-0` — drop behind any feature visual. Prefer
@@ -124,32 +127,21 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
     if (!ctx) return;
 
     const reduced = window.matchMedia("(prefers-reduced-motion: reduce)");
-    let run = pickRun(root, Math.random() < 0.5);
-    let runStarted = 0;
+    type Pulse = { run: Run; started: number };
+    const pulses: Pulse[] = [
+      { run: pickRun(root, true), started: 0 },
+      { run: pickRun(root, false), started: 0 },
+    ];
     let raf = 0;
     let visible = true;
 
-    const paintTravel = (now: number) => {
-      const { rect } = bounds(root);
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      if (runStarted === 0) runStarted = now;
-      let head =
-        run.start + run.dir * ((now - runStarted) / 1000) * CELLS_PER_SEC;
-      const past =
-        run.dir === 1
-          ? head > run.to + PULSE_SIGMA * 2
-          : head < run.from - PULSE_SIGMA * 2;
-      if (past) {
-        run = pickRun(root, !run.horizontal);
-        runStarted = now;
-        head = run.start;
-      }
+    const paintRun = (run: Run, head: number, rect: DOMRect) => {
       for (let depth = 0; depth < EDGE; depth++) {
         const axis = run.axis0 + run.inward * depth;
         const falloff = 1 - depth * 0.12;
         for (let i = run.from; i <= run.to; i++) {
           const b = bloom(i - head) * falloff;
-          if (b < 0.04) continue;
+          if (b < 0.02) continue;
           const gx = run.horizontal ? i : axis;
           const gy = run.horizontal ? axis : i;
           const r = 1.2 + b * 0.55;
@@ -157,6 +149,49 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
           drawDot(ctx, rect.left, rect.top, gx, gy, r * 1.55, a * 0.16);
           drawDot(ctx, rect.left, rect.top, gx, gy, r, a);
         }
+        const gx = run.horizontal ? head : axis;
+        const gy = run.horizontal ? axis : head;
+        const peak = falloff;
+        drawDot(
+          ctx,
+          rect.left,
+          rect.top,
+          gx,
+          gy,
+          1.2 + 0.55 * peak,
+          (0.22 + 0.5 * peak) * 0.7,
+        );
+      }
+    };
+
+    const headOf = (pulse: Pulse, now: number) =>
+      pulse.run.start +
+      pulse.run.dir * ((now - pulse.started) / 1000) * CELLS_PER_SEC;
+
+    const pastEnd = (run: Run, head: number) =>
+      run.dir === 1
+        ? head > run.to + PULSE_SIGMA * 2
+        : head < run.from - PULSE_SIGMA * 2;
+
+    const paintTravel = (now: number) => {
+      const { rect } = bounds(root);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      if (pulses[0]!.started === 0) {
+        pulses[0]!.started = now;
+        const span =
+          ((pulses[1]!.run.to - pulses[1]!.run.from) / CELLS_PER_SEC) * 1000;
+        pulses[1]!.started = now - span * 0.45;
+      }
+      for (let n = 0; n < pulses.length; n++) {
+        const pulse = pulses[n]!;
+        const other = pulses[1 - n]!;
+        let head = headOf(pulse, now);
+        if (pastEnd(pulse.run, head)) {
+          pulse.run = pickRun(root, !pulse.run.horizontal, other.run);
+          pulse.started = now;
+          head = pulse.run.start;
+        }
+        paintRun(pulse.run, head, rect);
       }
     };
 
@@ -164,15 +199,17 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
       const { rect } = bounds(root);
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       const pulse = 0.28 + 0.28 * (0.5 + 0.5 * Math.sin(now / 900));
-      const mid = ((run.from + run.to) / 2) | 0;
-      for (let depth = 0; depth < EDGE; depth++) {
-        const axis = run.axis0 + run.inward * depth;
-        for (const i of [mid - 3, mid, mid + 3]) {
-          if (i < run.from || i > run.to) continue;
-          const gx = run.horizontal ? i : axis;
-          const gy = run.horizontal ? axis : i;
-          drawDot(ctx, rect.left, rect.top, gx, gy, 2.1, pulse * 0.18);
-          drawDot(ctx, rect.left, rect.top, gx, gy, 1.5, pulse);
+      for (const item of pulses) {
+        const mid = ((item.run.from + item.run.to) / 2) | 0;
+        for (let depth = 0; depth < EDGE; depth++) {
+          const axis = item.run.axis0 + item.run.inward * depth;
+          for (const i of [mid - 3, mid, mid + 3]) {
+            if (i < item.run.from || i > item.run.to) continue;
+            const gx = item.run.horizontal ? i : axis;
+            const gy = item.run.horizontal ? axis : i;
+            drawDot(ctx, rect.left, rect.top, gx, gy, 2.1, pulse * 0.18);
+            drawDot(ctx, rect.left, rect.top, gx, gy, 1.5, pulse);
+          }
         }
       }
     };
@@ -185,8 +222,8 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
       canvas.style.width = `${width}px`;
       canvas.style.height = `${height}px`;
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      run = pickRun(root, run.horizontal);
-      runStarted = 0;
+      pulses[0] = { run: pickRun(root, true), started: 0 };
+      pulses[1] = { run: pickRun(root, false, pulses[0].run), started: 0 };
     };
 
     const tick = (now: number) => {

--- a/app/src/components/homepage/features/feature-dot-field.tsx
+++ b/app/src/components/homepage/features/feature-dot-field.tsx
@@ -13,6 +13,11 @@ const CELL = 22;
 const TRAIL = 7;
 /** Time to glide one lattice cell — interpolated, not a discrete hop. */
 const STEP_MS = 280;
+/**
+ * How many lattice cells from the stage rim the trail may occupy.
+ * 2 × 22px ≈ the lg:p-12 media inset, so the snake stays in the wash.
+ */
+const EDGE = 2;
 /** Honey `#E69135` — brand token, not a new colour. */
 const HONEY_RGB = "230, 145, 53";
 
@@ -29,6 +34,23 @@ function same(a: Pt, b: Pt) {
   return a[0] === b[0] && a[1] === b[1];
 }
 
+function onRim(
+  x: number,
+  y: number,
+  minX: number,
+  minY: number,
+  maxX: number,
+  maxY: number,
+  edge: number,
+) {
+  return (
+    x <= minX + edge - 1 ||
+    x >= maxX - edge + 1 ||
+    y <= minY + edge - 1 ||
+    y >= maxY - edge + 1
+  );
+}
+
 function pickDir(
   dir: Pt,
   x: number,
@@ -41,7 +63,13 @@ function pickDir(
   const fits = ([dx, dy]: Pt) => {
     const nx = x + dx;
     const ny = y + dy;
-    return nx >= minX && ny >= minY && nx <= maxX && ny <= maxY;
+    return (
+      nx >= minX &&
+      ny >= minY &&
+      nx <= maxX &&
+      ny <= maxY &&
+      onRim(nx, ny, minX, minY, maxX, maxY, EDGE)
+    );
   };
   const opposite: Pt = [-dir[0], -dir[1]];
   const turns = DIRS.filter(
@@ -94,7 +122,8 @@ export type FeatureDotFieldProps = {
 /**
  * Shared feature-stage backdrop: the homepage spot-grid (same cell / mix /
  * fixed rhythm as `.homepage-spot-grid`) plus a short honey trail that
- * glides the lattice. Frozen when the user prefers reduced motion.
+ * glides the outer two lattice cells (the media inset / frame).
+ * Frozen when the user prefers reduced motion.
  *
  * Positioned `absolute inset-0` — drop behind any feature visual. Prefer
  * {@link FeatureStage} when you also need the stacking wrapper.
@@ -143,8 +172,21 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
 
     const seed = () => {
       const { minX, minY, maxX, maxY } = bounds(root);
-      x = ((minX + maxX) / 2) | 0;
-      y = ((minY + maxY) / 2) | 0;
+      const depth = (Math.random() * EDGE) | 0;
+      const side = (Math.random() * 4) | 0;
+      if (side === 0) {
+        x = minX + ((Math.random() * (maxX - minX + 1)) | 0);
+        y = minY + depth;
+      } else if (side === 1) {
+        x = maxX - depth;
+        y = minY + ((Math.random() * (maxY - minY + 1)) | 0);
+      } else if (side === 2) {
+        x = minX + ((Math.random() * (maxX - minX + 1)) | 0);
+        y = maxY - depth;
+      } else {
+        x = minX + depth;
+        y = minY + ((Math.random() * (maxY - minY + 1)) | 0);
+      }
       dir = DIRS[(Math.random() * DIRS.length) | 0]!;
       trail = [[x, y]];
       for (let i = 1; i < TRAIL; i++) {
@@ -169,6 +211,17 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
 
     const step = () => {
       const { minX, minY, maxX, maxY } = bounds(root);
+      if (!onRim(x, y, minX, minY, maxX, maxY, EDGE)) {
+        const toLeft = x - minX;
+        const toRight = maxX - x;
+        const toTop = y - minY;
+        const toBottom = maxY - y;
+        const nearest = Math.min(toLeft, toRight, toTop, toBottom);
+        if (nearest === toLeft) x = minX + EDGE - 1;
+        else if (nearest === toRight) x = maxX - EDGE + 1;
+        else if (nearest === toTop) y = minY + EDGE - 1;
+        else y = maxY - EDGE + 1;
+      }
       dir = pickDir(dir, x, y, minX, minY, maxX, maxY);
       x += dir[0];
       y += dir[1];

--- a/app/src/components/homepage/features/feature-dot-field.tsx
+++ b/app/src/components/homepage/features/feature-dot-field.tsx
@@ -16,7 +16,7 @@ const CELL = 22;
  */
 const EDGE = 2;
 /** Travelling bloom width, in cells — wide enough to blend, not orb-sized. */
-const PULSE_SIGMA = 2.45;
+const PULSE_SIGMA = 3.15;
 const CELLS_PER_SEC = 8;
 /** Honey `#E69135` — brand token, not a new colour. */
 const HONEY_RGB = "230, 145, 53";
@@ -101,6 +101,15 @@ function bloom(dist: number) {
   return Math.exp(-(dist * dist) / (2 * PULSE_SIGMA * PULSE_SIGMA));
 }
 
+function smoothstep(t: number) {
+  const u = Math.min(1, Math.max(0, t));
+  return u * u * (3 - 2 * u);
+}
+
+function travelCells(run: Run) {
+  return run.to - run.from + PULSE_SIGMA * 4;
+}
+
 export type FeatureDotFieldProps = {
   /** Extra classes on the absolute-fill wrapper. */
   className?: string;
@@ -141,44 +150,46 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
         const falloff = 1 - depth * 0.12;
         for (let i = run.from; i <= run.to; i++) {
           const b = bloom(i - head) * falloff;
-          if (b < 0.02) continue;
+          if (b < 0.012) continue;
           const gx = run.horizontal ? i : axis;
           const gy = run.horizontal ? axis : i;
-          const r = 1.2 + b * 0.55;
-          const a = 0.22 + b * 0.5;
+          const r = 1.25 + b * 0.28;
+          const a = 0.16 + b * 0.52;
           drawDot(ctx, rect.left, rect.top, gx, gy, r * 1.55, a * 0.16);
           drawDot(ctx, rect.left, rect.top, gx, gy, r, a);
         }
       }
     };
 
-    const headOf = (pulse: Pulse, now: number) =>
-      pulse.run.start +
-      pulse.run.dir * ((now - pulse.started) / 1000) * CELLS_PER_SEC;
+    const headOf = (pulse: Pulse, now: number) => {
+      const travel = travelCells(pulse.run);
+      const duration = (travel / CELLS_PER_SEC) * 1000;
+      const e = smoothstep((now - pulse.started) / duration);
+      return pulse.run.start + pulse.run.dir * e * travel;
+    };
 
-    const pastEnd = (run: Run, head: number) =>
-      run.dir === 1
-        ? head > run.to + PULSE_SIGMA * 2
-        : head < run.from - PULSE_SIGMA * 2;
+    const pastEnd = (pulse: Pulse, now: number) => {
+      const travel = travelCells(pulse.run);
+      const duration = (travel / CELLS_PER_SEC) * 1000;
+      return now - pulse.started >= duration;
+    };
 
     const paintTravel = (now: number) => {
       const { rect } = bounds(root);
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       if (pulses[0]!.started === 0) {
         pulses[0]!.started = now;
-        const span =
-          ((pulses[1]!.run.to - pulses[1]!.run.from) / CELLS_PER_SEC) * 1000;
+        const span = (travelCells(pulses[1]!.run) / CELLS_PER_SEC) * 1000;
         pulses[1]!.started = now - span * 0.45;
       }
       for (let n = 0; n < pulses.length; n++) {
         const pulse = pulses[n]!;
         const other = pulses[1 - n]!;
-        let head = headOf(pulse, now);
-        if (pastEnd(pulse.run, head)) {
+        if (pastEnd(pulse, now)) {
           pulse.run = pickRun(root, !pulse.run.horizontal, other.run);
           pulse.started = now;
-          head = pulse.run.start;
         }
+        const head = headOf(pulse, now);
         paintRun(pulse.run, head, rect);
       }
     };

--- a/app/src/components/homepage/features/feature-dot-field.tsx
+++ b/app/src/components/homepage/features/feature-dot-field.tsx
@@ -10,75 +10,25 @@ import { cn } from "@/lib/utils";
 import styles from "../homepage.module.css";
 
 const CELL = 22;
-const TRAIL = 7;
-/** Time to glide one lattice cell — interpolated, not a discrete hop. */
-const STEP_MS = 280;
 /**
- * How many lattice cells from the stage rim the trail may occupy.
- * 2 × 22px ≈ the lg:p-12 media inset, so the snake stays in the wash.
+ * How many lattice cells from the stage rim a pulse may occupy.
+ * 2 × 22px ≈ the lg:p-12 media inset, so highlights stay in the wash.
  */
 const EDGE = 2;
+/** Travelling bloom width, in cells. */
+const PULSE_SIGMA = 1.55;
+const CELLS_PER_SEC = 5.2;
 /** Honey `#E69135` — brand token, not a new colour. */
 const HONEY_RGB = "230, 145, 53";
 
-type Pt = readonly [number, number];
-
-const DIRS: Pt[] = [
-  [1, 0],
-  [-1, 0],
-  [0, 1],
-  [0, -1],
-];
-
-function same(a: Pt, b: Pt) {
-  return a[0] === b[0] && a[1] === b[1];
-}
-
-function onRim(
-  x: number,
-  y: number,
-  minX: number,
-  minY: number,
-  maxX: number,
-  maxY: number,
-  edge: number,
-) {
-  return (
-    x <= minX + edge - 1 ||
-    x >= maxX - edge + 1 ||
-    y <= minY + edge - 1 ||
-    y >= maxY - edge + 1
-  );
-}
-
-function pickDir(
-  dir: Pt,
-  x: number,
-  y: number,
-  minX: number,
-  minY: number,
-  maxX: number,
-  maxY: number,
-): Pt {
-  const fits = ([dx, dy]: Pt) => {
-    const nx = x + dx;
-    const ny = y + dy;
-    return (
-      nx >= minX &&
-      ny >= minY &&
-      nx <= maxX &&
-      ny <= maxY &&
-      onRim(nx, ny, minX, minY, maxX, maxY, EDGE)
-    );
-  };
-  const opposite: Pt = [-dir[0], -dir[1]];
-  const turns = DIRS.filter(
-    (d) => !same(d, dir) && !same(d, opposite) && fits(d),
-  );
-  if (fits(dir) && (turns.length === 0 || Math.random() > 0.28)) return dir;
-  if (turns.length) return turns[(Math.random() * turns.length) | 0]!;
-  return fits(opposite) ? opposite : dir;
-}
+type Run = {
+  horizontal: boolean;
+  axis: number;
+  from: number;
+  to: number;
+  dir: 1 | -1;
+  start: number;
+};
 
 function honey(alpha: number) {
   return `rgba(${HONEY_RGB}, ${alpha})`;
@@ -114,16 +64,35 @@ function bounds(el: HTMLElement) {
   return { rect, minX, minY, maxX, maxY };
 }
 
+function pickRun(el: HTMLElement, horizontal: boolean): Run {
+  const { minX, minY, maxX, maxY } = bounds(el);
+  const depth = (Math.random() * EDGE) | 0;
+  const dir: 1 | -1 = Math.random() < 0.5 ? 1 : -1;
+  if (horizontal) {
+    const axis = Math.random() < 0.5 ? minY + depth : maxY - depth;
+    const from = minX;
+    const to = maxX;
+    return { horizontal, axis, from, to, dir, start: dir === 1 ? from : to };
+  }
+  const axis = Math.random() < 0.5 ? minX + depth : maxX - depth;
+  const from = minY;
+  const to = maxY;
+  return { horizontal, axis, from, to, dir, start: dir === 1 ? from : to };
+}
+
+function bloom(dist: number) {
+  return Math.exp(-(dist * dist) / (2 * PULSE_SIGMA * PULSE_SIGMA));
+}
+
 export type FeatureDotFieldProps = {
   /** Extra classes on the absolute-fill wrapper. */
   className?: string;
 };
 
 /**
- * Shared feature-stage backdrop: the homepage spot-grid (same cell / mix /
- * fixed rhythm as `.homepage-spot-grid`) plus a short honey trail that
- * glides the outer two lattice cells (the media inset / frame).
- * Frozen when the user prefers reduced motion.
+ * Shared feature-stage backdrop: the homepage spot-grid plus honey dots that
+ * pulse along one horizontal or vertical rim run (outer two lattice cells).
+ * `prefers-reduced-motion` keeps a gentle in-place pulse.
  *
  * Positioned `absolute inset-0` — drop behind any feature visual. Prefer
  * {@link FeatureStage} when you also need the stacking wrapper.
@@ -141,59 +110,45 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
     if (!ctx) return;
 
     const reduced = window.matchMedia("(prefers-reduced-motion: reduce)");
-    let x = 0;
-    let y = 0;
-    let dir: Pt = DIRS[0]!;
-    let trail: Pt[] = [];
-    let last = 0;
+    let run = pickRun(root, Math.random() < 0.5);
+    let runStarted = 0;
     let raf = 0;
     let visible = true;
 
-    const paint = (progress: number) => {
+    const paintTravel = (now: number) => {
       const { rect } = bounds(root);
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      const p = Math.min(1, Math.max(0, progress));
-      trail.forEach((to, i) => {
-        const from = trail[i + 1] ?? to;
-        const gx = from[0] + (to[0] - from[0]) * p;
-        const gy = from[1] + (to[1] - from[1]) * p;
-        const t = 1 - i / TRAIL;
-        drawDot(
-          ctx,
-          rect.left,
-          rect.top,
-          gx,
-          gy,
-          1.15 + t * 0.45,
-          0.22 + t * 0.78,
-        );
-      });
+      if (runStarted === 0) runStarted = now;
+      let head =
+        run.start + run.dir * ((now - runStarted) / 1000) * CELLS_PER_SEC;
+      const past =
+        run.dir === 1
+          ? head > run.to + PULSE_SIGMA * 2
+          : head < run.from - PULSE_SIGMA * 2;
+      if (past) {
+        run = pickRun(root, !run.horizontal);
+        runStarted = now;
+        head = run.start;
+      }
+      for (let i = run.from; i <= run.to; i++) {
+        const b = bloom(i - head);
+        if (b < 0.05) continue;
+        const gx = run.horizontal ? i : run.axis;
+        const gy = run.horizontal ? run.axis : i;
+        drawDot(ctx, rect.left, rect.top, gx, gy, 1.1 + b * 0.7, 0.1 + b * 0.9);
+      }
     };
 
-    const seed = () => {
-      const { minX, minY, maxX, maxY } = bounds(root);
-      const depth = (Math.random() * EDGE) | 0;
-      const side = (Math.random() * 4) | 0;
-      if (side === 0) {
-        x = minX + ((Math.random() * (maxX - minX + 1)) | 0);
-        y = minY + depth;
-      } else if (side === 1) {
-        x = maxX - depth;
-        y = minY + ((Math.random() * (maxY - minY + 1)) | 0);
-      } else if (side === 2) {
-        x = minX + ((Math.random() * (maxX - minX + 1)) | 0);
-        y = maxY - depth;
-      } else {
-        x = minX + depth;
-        y = minY + ((Math.random() * (maxY - minY + 1)) | 0);
-      }
-      dir = DIRS[(Math.random() * DIRS.length) | 0]!;
-      trail = [[x, y]];
-      for (let i = 1; i < TRAIL; i++) {
-        dir = pickDir(dir, x, y, minX, minY, maxX, maxY);
-        x += dir[0];
-        y += dir[1];
-        trail.unshift([x, y]);
+    const paintRest = (now: number) => {
+      const { rect } = bounds(root);
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      const pulse = 0.28 + 0.32 * (0.5 + 0.5 * Math.sin(now / 900));
+      const mid = ((run.from + run.to) / 2) | 0;
+      for (const i of [mid - 2, mid, mid + 2]) {
+        if (i < run.from || i > run.to) continue;
+        const gx = run.horizontal ? i : run.axis;
+        const gy = run.horizontal ? run.axis : i;
+        drawDot(ctx, rect.left, rect.top, gx, gy, 1.25, pulse);
       }
     };
 
@@ -205,56 +160,22 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
       canvas.style.width = `${width}px`;
       canvas.style.height = `${height}px`;
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      seed();
-      paint(1);
-    };
-
-    const step = () => {
-      const { minX, minY, maxX, maxY } = bounds(root);
-      if (!onRim(x, y, minX, minY, maxX, maxY, EDGE)) {
-        const toLeft = x - minX;
-        const toRight = maxX - x;
-        const toTop = y - minY;
-        const toBottom = maxY - y;
-        const nearest = Math.min(toLeft, toRight, toTop, toBottom);
-        if (nearest === toLeft) x = minX + EDGE - 1;
-        else if (nearest === toRight) x = maxX - EDGE + 1;
-        else if (nearest === toTop) y = minY + EDGE - 1;
-        else y = maxY - EDGE + 1;
-      }
-      dir = pickDir(dir, x, y, minX, minY, maxX, maxY);
-      x += dir[0];
-      y += dir[1];
-      trail.unshift([x, y]);
-      trail.length = TRAIL;
+      run = pickRun(root, run.horizontal);
+      runStarted = 0;
     };
 
     const tick = (now: number) => {
-      if (visible && !reduced.matches) {
-        if (last === 0) last = now;
-        const progress = Math.min(1, (now - last) / STEP_MS);
-        paint(progress);
-        if (progress >= 1) {
-          last = now;
-          step();
-        }
+      if (visible) {
+        if (reduced.matches) paintRest(now);
+        else paintTravel(now);
       }
-      raf = requestAnimationFrame(tick);
-    };
-
-    const syncMotion = () => {
-      cancelAnimationFrame(raf);
-      if (reduced.matches) {
-        paint(1);
-        return;
-      }
-      last = 0;
       raf = requestAnimationFrame(tick);
     };
 
     const ro = new ResizeObserver(layout);
     ro.observe(root);
     layout();
+    raf = requestAnimationFrame(tick);
 
     const io = new IntersectionObserver(
       ([entry]) => {
@@ -264,14 +185,10 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
     );
     io.observe(root);
 
-    reduced.addEventListener("change", syncMotion);
-    syncMotion();
-
     return () => {
       cancelAnimationFrame(raf);
       ro.disconnect();
       io.disconnect();
-      reduced.removeEventListener("change", syncMotion);
     };
   }, []);
 
@@ -305,9 +222,9 @@ export type FeatureStageProps = PropsWithChildren<{
 }>;
 
 /**
- * Right-panel feature stage: lattice + honey trail behind a floating visual.
+ * Right-panel feature stage: lattice + honey pulse behind a floating visual.
  * Parent must be `position: relative`. Later feature-visual PRs wrap their
- * media in this — do not fork the trail.
+ * media in this — do not fork the pulse.
  */
 export function FeatureStage({ children, className }: FeatureStageProps) {
   return (

--- a/app/src/components/homepage/features/feature-dot-field.tsx
+++ b/app/src/components/homepage/features/feature-dot-field.tsx
@@ -39,8 +39,6 @@ function honey(alpha: number) {
 
 function drawDot(
   ctx: CanvasRenderingContext2D,
-  left: number,
-  top: number,
   gx: number,
   gy: number,
   r: number,
@@ -48,23 +46,20 @@ function drawDot(
 ) {
   ctx.beginPath();
   ctx.fillStyle = honey(alpha);
-  ctx.arc(
-    gx * CELL + CELL / 2 - left,
-    gy * CELL + CELL / 2 - top,
-    r,
-    0,
-    Math.PI * 2,
-  );
+  ctx.arc(gx * CELL + CELL / 2, gy * CELL + CELL / 2, r, 0, Math.PI * 2);
   ctx.fill();
 }
 
+/** Lattice in the field’s own box — not viewport cells — so it scrolls with the card. */
 function bounds(el: HTMLElement) {
-  const rect = el.getBoundingClientRect();
-  const minX = Math.floor(rect.left / CELL);
-  const minY = Math.floor(rect.top / CELL);
-  const maxX = Math.ceil(rect.right / CELL) - 1;
-  const maxY = Math.ceil(rect.bottom / CELL) - 1;
-  return { rect, minX, minY, maxX, maxY };
+  const width = el.clientWidth;
+  const height = el.clientHeight;
+  return {
+    minX: 0,
+    minY: 0,
+    maxX: Math.max(0, Math.ceil(width / CELL) - 1),
+    maxY: Math.max(0, Math.ceil(height / CELL) - 1),
+  };
 }
 
 /** Deterministic 0–1 from a per-card seed so reloads keep the same motion. */
@@ -153,7 +148,8 @@ export type FeatureDotFieldProps = {
  * blooms that pulse along rim strips (one H, one V; both EDGE rings).
  * `prefers-reduced-motion` keeps a gentle in-place pulse.
  *
- * Positioned `absolute inset-0` — drop behind any feature visual. Prefer
+ * Lattice and spot-grid are local to this box (not viewport-fixed) so they
+ * travel with the sticky paper card. Positioned `absolute inset-0`. Prefer
  * {@link FeatureStage} when you also need the stacking wrapper.
  */
 export function FeatureDotField({ className, seed = 0 }: FeatureDotFieldProps) {
@@ -189,7 +185,7 @@ export function FeatureDotField({ className, seed = 0 }: FeatureDotFieldProps) {
     let raf = 0;
     let visible = true;
 
-    const paintRun = (run: Run, head: number, rect: DOMRect) => {
+    const paintRun = (run: Run, head: number) => {
       for (let depth = 0; depth < EDGE; depth++) {
         const axis = run.axis0 + run.inward * depth;
         const falloff = 1 - depth * 0.12;
@@ -200,8 +196,8 @@ export function FeatureDotField({ className, seed = 0 }: FeatureDotFieldProps) {
           const gy = run.horizontal ? axis : i;
           const r = 1.25 + b * 0.28;
           const a = 0.16 + b * 0.52;
-          drawDot(ctx, rect.left, rect.top, gx, gy, r * 1.55, a * 0.16);
-          drawDot(ctx, rect.left, rect.top, gx, gy, r, a);
+          drawDot(ctx, gx, gy, r * 1.55, a * 0.16);
+          drawDot(ctx, gx, gy, r, a);
         }
       }
     };
@@ -219,7 +215,6 @@ export function FeatureDotField({ className, seed = 0 }: FeatureDotFieldProps) {
     };
 
     const paintTravel = (now: number) => {
-      const { rect } = bounds(root);
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       if (pulses[0]!.started === 0) {
         pulses[0]!.started = now - durationOf(pulses[0]!.run) * phase0;
@@ -232,13 +227,11 @@ export function FeatureDotField({ className, seed = 0 }: FeatureDotFieldProps) {
           pulse.run = pickRun(root, !pulse.run.horizontal, rand, other.run);
           pulse.started = now;
         }
-        const head = headOf(pulse, now);
-        paintRun(pulse.run, head, rect);
+        paintRun(pulse.run, headOf(pulse, now));
       }
     };
 
     const paintRest = (now: number) => {
-      const { rect } = bounds(root);
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       const pulse = 0.28 + 0.28 * (0.5 + 0.5 * Math.sin(now / 900 + restPhase));
       for (const item of pulses) {
@@ -249,8 +242,8 @@ export function FeatureDotField({ className, seed = 0 }: FeatureDotFieldProps) {
             if (i < item.run.from || i > item.run.to) continue;
             const gx = item.run.horizontal ? i : axis;
             const gy = item.run.horizontal ? axis : i;
-            drawDot(ctx, rect.left, rect.top, gx, gy, 2.1, pulse * 0.18);
-            drawDot(ctx, rect.left, rect.top, gx, gy, 1.5, pulse);
+            drawDot(ctx, gx, gy, 2.1, pulse * 0.18);
+            drawDot(ctx, gx, gy, 1.5, pulse);
           }
         }
       }
@@ -315,7 +308,7 @@ export function FeatureDotField({ className, seed = 0 }: FeatureDotFieldProps) {
           {
             "--homepage-dot-color": "white",
             "--homepage-dot-mix": "8%",
-            "--homepage-dot-attachment": "fixed",
+            "--homepage-dot-attachment": "scroll",
             "--homepage-dot-position": "0 0",
           } as CSSProperties
         }

--- a/app/src/components/homepage/features/feature-dot-field.tsx
+++ b/app/src/components/homepage/features/feature-dot-field.tsx
@@ -11,19 +11,22 @@ import styles from "../homepage.module.css";
 
 const CELL = 22;
 /**
- * How many lattice cells from the stage rim a pulse may occupy.
- * 2 × 22px ≈ the lg:p-12 media inset, so highlights stay in the wash.
+ * Rim band depth in lattice cells. 2 × 22px sits in the lg:p-12 inset;
+ * both rings of the active side light so the wash reads at a glance.
  */
 const EDGE = 2;
 /** Travelling bloom width, in cells. */
-const PULSE_SIGMA = 1.55;
-const CELLS_PER_SEC = 5.2;
+const PULSE_SIGMA = 2.8;
+const CELLS_PER_SEC = 4;
 /** Honey `#E69135` — brand token, not a new colour. */
 const HONEY_RGB = "230, 145, 53";
 
 type Run = {
   horizontal: boolean;
-  axis: number;
+  /** Outer-rim cell on the chosen side. */
+  axis0: number;
+  /** +1 / −1 toward the stage interior. */
+  inward: 1 | -1;
   from: number;
   to: number;
   dir: 1 | -1;
@@ -66,18 +69,29 @@ function bounds(el: HTMLElement) {
 
 function pickRun(el: HTMLElement, horizontal: boolean): Run {
   const { minX, minY, maxX, maxY } = bounds(el);
-  const depth = (Math.random() * EDGE) | 0;
   const dir: 1 | -1 = Math.random() < 0.5 ? 1 : -1;
   if (horizontal) {
-    const axis = Math.random() < 0.5 ? minY + depth : maxY - depth;
-    const from = minX;
-    const to = maxX;
-    return { horizontal, axis, from, to, dir, start: dir === 1 ? from : to };
+    const top = Math.random() < 0.5;
+    return {
+      horizontal,
+      axis0: top ? minY : maxY,
+      inward: top ? 1 : -1,
+      from: minX,
+      to: maxX,
+      dir,
+      start: dir === 1 ? minX : maxX,
+    };
   }
-  const axis = Math.random() < 0.5 ? minX + depth : maxX - depth;
-  const from = minY;
-  const to = maxY;
-  return { horizontal, axis, from, to, dir, start: dir === 1 ? from : to };
+  const left = Math.random() < 0.5;
+  return {
+    horizontal,
+    axis0: left ? minX : maxX,
+    inward: left ? 1 : -1,
+    from: minY,
+    to: maxY,
+    dir,
+    start: dir === 1 ? minY : maxY,
+  };
 }
 
 function bloom(dist: number) {
@@ -91,7 +105,7 @@ export type FeatureDotFieldProps = {
 
 /**
  * Shared feature-stage backdrop: the homepage spot-grid plus honey dots that
- * pulse along one horizontal or vertical rim run (outer two lattice cells).
+ * pulse along one horizontal or vertical rim strip (both EDGE rings).
  * `prefers-reduced-motion` keeps a gentle in-place pulse.
  *
  * Positioned `absolute inset-0` — drop behind any feature visual. Prefer
@@ -130,25 +144,36 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
         runStarted = now;
         head = run.start;
       }
-      for (let i = run.from; i <= run.to; i++) {
-        const b = bloom(i - head);
-        if (b < 0.05) continue;
-        const gx = run.horizontal ? i : run.axis;
-        const gy = run.horizontal ? run.axis : i;
-        drawDot(ctx, rect.left, rect.top, gx, gy, 1.1 + b * 0.7, 0.1 + b * 0.9);
+      for (let depth = 0; depth < EDGE; depth++) {
+        const axis = run.axis0 + run.inward * depth;
+        const falloff = 1 - depth * 0.12;
+        for (let i = run.from; i <= run.to; i++) {
+          const b = bloom(i - head) * falloff;
+          if (b < 0.04) continue;
+          const gx = run.horizontal ? i : axis;
+          const gy = run.horizontal ? axis : i;
+          const r = 2.4 + b * 2.2;
+          const a = 0.4 + b * 0.6;
+          drawDot(ctx, rect.left, rect.top, gx, gy, r * 2.1, a * 0.28);
+          drawDot(ctx, rect.left, rect.top, gx, gy, r, a);
+        }
       }
     };
 
     const paintRest = (now: number) => {
       const { rect } = bounds(root);
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      const pulse = 0.28 + 0.32 * (0.5 + 0.5 * Math.sin(now / 900));
+      const pulse = 0.45 + 0.4 * (0.5 + 0.5 * Math.sin(now / 900));
       const mid = ((run.from + run.to) / 2) | 0;
-      for (const i of [mid - 2, mid, mid + 2]) {
-        if (i < run.from || i > run.to) continue;
-        const gx = run.horizontal ? i : run.axis;
-        const gy = run.horizontal ? run.axis : i;
-        drawDot(ctx, rect.left, rect.top, gx, gy, 1.25, pulse);
+      for (let depth = 0; depth < EDGE; depth++) {
+        const axis = run.axis0 + run.inward * depth;
+        for (const i of [mid - 3, mid, mid + 3]) {
+          if (i < run.from || i > run.to) continue;
+          const gx = run.horizontal ? i : axis;
+          const gy = run.horizontal ? axis : i;
+          drawDot(ctx, rect.left, rect.top, gx, gy, 3.2, pulse * 0.3);
+          drawDot(ctx, rect.left, rect.top, gx, gy, 2.6, pulse);
+        }
       }
     };
 

--- a/app/src/components/homepage/features/feature-dot-field.tsx
+++ b/app/src/components/homepage/features/feature-dot-field.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { type CSSProperties, useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
+import styles from "../homepage.module.css";
+
+const CELL = 22;
+const TRAIL = 7;
+const STEP_MS = 150;
+/** Honey `#E69135` — brand token, not a new colour. */
+const HONEY_RGB = "230, 145, 53";
+
+type Pt = readonly [number, number];
+
+const DIRS: Pt[] = [
+  [1, 0],
+  [-1, 0],
+  [0, 1],
+  [0, -1],
+];
+
+function same(a: Pt, b: Pt) {
+  return a[0] === b[0] && a[1] === b[1];
+}
+
+function pickDir(
+  dir: Pt,
+  x: number,
+  y: number,
+  cols: number,
+  rows: number,
+): Pt {
+  const fits = ([dx, dy]: Pt) => {
+    const nx = x + dx;
+    const ny = y + dy;
+    return nx >= 0 && ny >= 0 && nx < cols && ny < rows;
+  };
+  const opposite: Pt = [-dir[0], -dir[1]];
+  const turns = DIRS.filter(
+    (d) => !same(d, dir) && !same(d, opposite) && fits(d),
+  );
+  if (fits(dir) && (turns.length === 0 || Math.random() > 0.28)) return dir;
+  if (turns.length) return turns[(Math.random() * turns.length) | 0]!;
+  return fits(opposite) ? opposite : dir;
+}
+
+function staticHighlights(cols: number, rows: number): Pt[] {
+  return (
+    [
+      [3, 2],
+      [cols - 4, 4],
+      [7, rows - 3],
+      [cols - 6, rows - 5],
+      [(cols * 0.4) | 0, (rows * 0.55) | 0],
+    ] as Pt[]
+  ).filter(([x, y]) => x > 0 && y > 0 && x < cols && y < rows);
+}
+
+function honey(alpha: number) {
+  return `rgba(${HONEY_RGB}, ${alpha})`;
+}
+
+function drawDot(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  r: number,
+  alpha: number,
+) {
+  ctx.beginPath();
+  ctx.fillStyle = honey(alpha);
+  ctx.arc(x * CELL + CELL / 2, y * CELL + CELL / 2, r, 0, Math.PI * 2);
+  ctx.fill();
+}
+
+/**
+ * Periwinkle lattice (reuses `homepage-spot-grid-card`) plus a short honey
+ * trail that walks the grid horizontally and vertically. Frozen when the
+ * user prefers reduced motion.
+ */
+export function FeatureDotField({ className }: { className?: string }) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    const canvas = canvasRef.current;
+    if (!root || !canvas) return;
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const reduced = window.matchMedia("(prefers-reduced-motion: reduce)");
+    let cols = 0;
+    let rows = 0;
+    let x = 0;
+    let y = 0;
+    let dir: Pt = DIRS[0]!;
+    let trail: Pt[] = [];
+    let highlights: Pt[] = [];
+    let last = 0;
+    let raf = 0;
+    let visible = true;
+
+    const paint = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      for (const [hx, hy] of highlights) drawDot(ctx, hx, hy, 1.15, 0.55);
+      trail.forEach(([tx, ty], i) => {
+        const t = 1 - i / TRAIL;
+        drawDot(ctx, tx, ty, 1.15 + t * 0.45, 0.22 + t * 0.78);
+      });
+    };
+
+    const layout = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const { width, height } = root.getBoundingClientRect();
+      canvas.width = Math.max(1, Math.floor(width * dpr));
+      canvas.height = Math.max(1, Math.floor(height * dpr));
+      canvas.style.width = `${width}px`;
+      canvas.style.height = `${height}px`;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      cols = Math.max(2, Math.ceil(width / CELL));
+      rows = Math.max(2, Math.ceil(height / CELL));
+      x = (cols / 2) | 0;
+      y = (rows / 2) | 0;
+      dir = DIRS[(Math.random() * DIRS.length) | 0]!;
+      trail = [[x, y]];
+      for (let i = 1; i < TRAIL; i++) {
+        dir = pickDir(dir, x, y, cols, rows);
+        x += dir[0];
+        y += dir[1];
+        trail.unshift([x, y]);
+      }
+      highlights = staticHighlights(cols, rows);
+      paint();
+    };
+
+    const step = () => {
+      dir = pickDir(dir, x, y, cols, rows);
+      x += dir[0];
+      y += dir[1];
+      trail.unshift([x, y]);
+      trail.length = TRAIL;
+      paint();
+    };
+
+    const tick = (now: number) => {
+      if (visible && !reduced.matches && now - last >= STEP_MS) {
+        last = now;
+        step();
+      }
+      raf = requestAnimationFrame(tick);
+    };
+
+    const syncMotion = () => {
+      cancelAnimationFrame(raf);
+      if (reduced.matches) {
+        paint();
+        return;
+      }
+      last = 0;
+      raf = requestAnimationFrame(tick);
+    };
+
+    const ro = new ResizeObserver(layout);
+    ro.observe(root);
+    layout();
+
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        visible = entry?.isIntersecting ?? true;
+      },
+      { threshold: 0 },
+    );
+    io.observe(root);
+
+    reduced.addEventListener("change", syncMotion);
+    syncMotion();
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      io.disconnect();
+      reduced.removeEventListener("change", syncMotion);
+    };
+  }, []);
+
+  return (
+    <div
+      ref={rootRef}
+      className={cn(
+        "pointer-events-none absolute inset-0 overflow-hidden",
+        className,
+      )}
+      aria-hidden
+    >
+      <div
+        className={cn(styles["homepage-spot-grid-card"], "absolute inset-0")}
+        style={
+          {
+            "--homepage-dot-color": "var(--color-periwinkle-500)",
+            "--homepage-dot-mix": "10%",
+          } as CSSProperties
+        }
+      />
+      <canvas ref={canvasRef} className="absolute inset-0" />
+    </div>
+  );
+}

--- a/app/src/components/homepage/features/feature-dot-field.tsx
+++ b/app/src/components/homepage/features/feature-dot-field.tsx
@@ -11,7 +11,8 @@ import styles from "../homepage.module.css";
 
 const CELL = 22;
 const TRAIL = 7;
-const STEP_MS = 150;
+/** Time to glide one lattice cell — interpolated, not a discrete hop. */
+const STEP_MS = 280;
 /** Honey `#E69135` — brand token, not a new colour. */
 const HONEY_RGB = "230, 145, 53";
 
@@ -32,13 +33,15 @@ function pickDir(
   dir: Pt,
   x: number,
   y: number,
-  cols: number,
-  rows: number,
+  minX: number,
+  minY: number,
+  maxX: number,
+  maxY: number,
 ): Pt {
   const fits = ([dx, dy]: Pt) => {
     const nx = x + dx;
     const ny = y + dy;
-    return nx >= 0 && ny >= 0 && nx < cols && ny < rows;
+    return nx >= minX && ny >= minY && nx <= maxX && ny <= maxY;
   };
   const opposite: Pt = [-dir[0], -dir[1]];
   const turns = DIRS.filter(
@@ -49,33 +52,38 @@ function pickDir(
   return fits(opposite) ? opposite : dir;
 }
 
-function staticHighlights(cols: number, rows: number): Pt[] {
-  return (
-    [
-      [3, 2],
-      [cols - 4, 4],
-      [7, rows - 3],
-      [cols - 6, rows - 5],
-      [(cols * 0.4) | 0, (rows * 0.55) | 0],
-    ] as Pt[]
-  ).filter(([x, y]) => x > 0 && y > 0 && x < cols && y < rows);
-}
-
 function honey(alpha: number) {
   return `rgba(${HONEY_RGB}, ${alpha})`;
 }
 
 function drawDot(
   ctx: CanvasRenderingContext2D,
-  x: number,
-  y: number,
+  left: number,
+  top: number,
+  gx: number,
+  gy: number,
   r: number,
   alpha: number,
 ) {
   ctx.beginPath();
   ctx.fillStyle = honey(alpha);
-  ctx.arc(x * CELL + CELL / 2, y * CELL + CELL / 2, r, 0, Math.PI * 2);
+  ctx.arc(
+    gx * CELL + CELL / 2 - left,
+    gy * CELL + CELL / 2 - top,
+    r,
+    0,
+    Math.PI * 2,
+  );
   ctx.fill();
+}
+
+function bounds(el: HTMLElement) {
+  const rect = el.getBoundingClientRect();
+  const minX = Math.floor(rect.left / CELL);
+  const minY = Math.floor(rect.top / CELL);
+  const maxX = Math.ceil(rect.right / CELL) - 1;
+  const maxY = Math.ceil(rect.bottom / CELL) - 1;
+  return { rect, minX, minY, maxX, maxY };
 }
 
 export type FeatureDotFieldProps = {
@@ -84,9 +92,9 @@ export type FeatureDotFieldProps = {
 };
 
 /**
- * Shared feature-stage backdrop: periwinkle lattice (reuses
- * `homepage-spot-grid-card`) plus a short honey trail that walks the grid
- * horizontally and vertically. Frozen when the user prefers reduced motion.
+ * Shared feature-stage backdrop: the homepage spot-grid (same cell / mix /
+ * fixed rhythm as `.homepage-spot-grid`) plus a short honey trail that
+ * glides the lattice. Frozen when the user prefers reduced motion.
  *
  * Positioned `absolute inset-0` — drop behind any feature visual. Prefer
  * {@link FeatureStage} when you also need the stacking wrapper.
@@ -104,24 +112,47 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
     if (!ctx) return;
 
     const reduced = window.matchMedia("(prefers-reduced-motion: reduce)");
-    let cols = 0;
-    let rows = 0;
     let x = 0;
     let y = 0;
     let dir: Pt = DIRS[0]!;
     let trail: Pt[] = [];
-    let highlights: Pt[] = [];
     let last = 0;
     let raf = 0;
     let visible = true;
 
-    const paint = () => {
+    const paint = (progress: number) => {
+      const { rect } = bounds(root);
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      for (const [hx, hy] of highlights) drawDot(ctx, hx, hy, 1.15, 0.55);
-      trail.forEach(([tx, ty], i) => {
+      const p = Math.min(1, Math.max(0, progress));
+      trail.forEach((to, i) => {
+        const from = trail[i + 1] ?? to;
+        const gx = from[0] + (to[0] - from[0]) * p;
+        const gy = from[1] + (to[1] - from[1]) * p;
         const t = 1 - i / TRAIL;
-        drawDot(ctx, tx, ty, 1.15 + t * 0.45, 0.22 + t * 0.78);
+        drawDot(
+          ctx,
+          rect.left,
+          rect.top,
+          gx,
+          gy,
+          1.15 + t * 0.45,
+          0.22 + t * 0.78,
+        );
       });
+    };
+
+    const seed = () => {
+      const { minX, minY, maxX, maxY } = bounds(root);
+      x = ((minX + maxX) / 2) | 0;
+      y = ((minY + maxY) / 2) | 0;
+      dir = DIRS[(Math.random() * DIRS.length) | 0]!;
+      trail = [[x, y]];
+      for (let i = 1; i < TRAIL; i++) {
+        dir = pickDir(dir, x, y, minX, minY, maxX, maxY);
+        x += dir[0];
+        y += dir[1];
+        trail.unshift([x, y]);
+      }
     };
 
     const layout = () => {
@@ -132,35 +163,28 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
       canvas.style.width = `${width}px`;
       canvas.style.height = `${height}px`;
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      cols = Math.max(2, Math.ceil(width / CELL));
-      rows = Math.max(2, Math.ceil(height / CELL));
-      x = (cols / 2) | 0;
-      y = (rows / 2) | 0;
-      dir = DIRS[(Math.random() * DIRS.length) | 0]!;
-      trail = [[x, y]];
-      for (let i = 1; i < TRAIL; i++) {
-        dir = pickDir(dir, x, y, cols, rows);
-        x += dir[0];
-        y += dir[1];
-        trail.unshift([x, y]);
-      }
-      highlights = staticHighlights(cols, rows);
-      paint();
+      seed();
+      paint(1);
     };
 
     const step = () => {
-      dir = pickDir(dir, x, y, cols, rows);
+      const { minX, minY, maxX, maxY } = bounds(root);
+      dir = pickDir(dir, x, y, minX, minY, maxX, maxY);
       x += dir[0];
       y += dir[1];
       trail.unshift([x, y]);
       trail.length = TRAIL;
-      paint();
     };
 
     const tick = (now: number) => {
-      if (visible && !reduced.matches && now - last >= STEP_MS) {
-        last = now;
-        step();
+      if (visible && !reduced.matches) {
+        if (last === 0) last = now;
+        const progress = Math.min(1, (now - last) / STEP_MS);
+        paint(progress);
+        if (progress >= 1) {
+          last = now;
+          step();
+        }
       }
       raf = requestAnimationFrame(tick);
     };
@@ -168,7 +192,7 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
     const syncMotion = () => {
       cancelAnimationFrame(raf);
       if (reduced.matches) {
-        paint();
+        paint(1);
         return;
       }
       last = 0;
@@ -211,8 +235,10 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
         className={cn(styles["homepage-spot-grid-card"], "absolute inset-0")}
         style={
           {
-            "--homepage-dot-color": "var(--color-periwinkle-500)",
-            "--homepage-dot-mix": "10%",
+            "--homepage-dot-color": "white",
+            "--homepage-dot-mix": "8%",
+            "--homepage-dot-attachment": "fixed",
+            "--homepage-dot-position": "0 0",
           } as CSSProperties
         }
       />

--- a/app/src/components/homepage/features/feature-dot-field.tsx
+++ b/app/src/components/homepage/features/feature-dot-field.tsx
@@ -15,9 +15,10 @@ const CELL = 22;
  * both rings of the active side light so the wash reads at a glance.
  */
 const EDGE = 2;
-/** Travelling bloom width, in cells — wide enough to blend, not orb-sized. */
-const PULSE_SIGMA = 3.15;
-const CELLS_PER_SEC = 8;
+/** Travelling bloom width, in cells — wider than the old 3.15 so the peak blends. */
+const PULSE_SIGMA = 4.5;
+/** Head speed; seed multiplies ~0.90–1.10 so cards stay ~12.6–15.4 cells/sec. */
+const CELLS_PER_SEC = 14;
 /** Honey `#E69135` — brand token, not a new colour. */
 const HONEY_RGB = "230, 145, 53";
 
@@ -123,11 +124,6 @@ function bloom(dist: number) {
   return Math.exp(-(dist * dist) / (2 * PULSE_SIGMA * PULSE_SIGMA));
 }
 
-function smoothstep(t: number) {
-  const u = Math.min(1, Math.max(0, t));
-  return u * u * (3 - 2 * u);
-}
-
 function travelCells(run: Run) {
   return run.to - run.from + PULSE_SIGMA * 4;
 }
@@ -168,7 +164,7 @@ export function FeatureDotField({ className, seed = 0 }: FeatureDotFieldProps) {
     // Motion params and rim-run sequence use separate streams so a
     // layout() re-seed does not replay the phase/speed draws as edges.
     const motion = mulberry32(hashSeed(seed));
-    const cellsPerSec = CELLS_PER_SEC * (0.86 + motion() * 0.28);
+    const cellsPerSec = CELLS_PER_SEC * (0.9 + motion() * 0.2);
     const leadHorizontal = motion() < 0.5;
     const phase0 = motion();
     const phase1 = motion();
@@ -191,11 +187,12 @@ export function FeatureDotField({ className, seed = 0 }: FeatureDotFieldProps) {
         const falloff = 1 - depth * 0.12;
         for (let i = run.from; i <= run.to; i++) {
           const b = bloom(i - head) * falloff;
-          if (b < 0.012) continue;
+          if (b < 0.008) continue;
           const gx = run.horizontal ? i : axis;
           const gy = run.horizontal ? axis : i;
-          const r = 1.25 + b * 0.28;
-          const a = 0.16 + b * 0.52;
+          const soft = b * b * (3 - 2 * b);
+          const r = 1.2 + soft * 0.32;
+          const a = 0.1 + soft * 0.42;
           drawDot(ctx, gx, gy, r * 1.55, a * 0.16);
           drawDot(ctx, gx, gy, r, a);
         }
@@ -206,7 +203,10 @@ export function FeatureDotField({ className, seed = 0 }: FeatureDotFieldProps) {
 
     const headOf = (pulse: Pulse, now: number) => {
       const travel = travelCells(pulse.run);
-      const e = smoothstep((now - pulse.started) / durationOf(pulse.run));
+      const e = Math.min(
+        1,
+        Math.max(0, (now - pulse.started) / durationOf(pulse.run)),
+      );
       return pulse.run.start + pulse.run.dir * e * travel;
     };
 
@@ -233,7 +233,7 @@ export function FeatureDotField({ className, seed = 0 }: FeatureDotFieldProps) {
 
     const paintRest = (now: number) => {
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      const pulse = 0.28 + 0.28 * (0.5 + 0.5 * Math.sin(now / 900 + restPhase));
+      const pulse = 0.26 + 0.22 * (0.5 + 0.5 * Math.sin(now / 720 + restPhase));
       for (const item of pulses) {
         const mid = ((item.run.from + item.run.to) / 2) | 0;
         for (let depth = 0; depth < EDGE; depth++) {

--- a/app/src/components/homepage/features/feature-dot-field.tsx
+++ b/app/src/components/homepage/features/feature-dot-field.tsx
@@ -67,12 +67,39 @@ function bounds(el: HTMLElement) {
   return { rect, minX, minY, maxX, maxY };
 }
 
-function pickRun(el: HTMLElement, horizontal: boolean, avoid?: Run): Run {
+/** Deterministic 0–1 from a per-card seed so reloads keep the same motion. */
+function hashSeed(seed: number | string): number {
+  const str = String(seed);
+  let h = 2166136261;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function mulberry32(seed: number) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pickRun(
+  el: HTMLElement,
+  horizontal: boolean,
+  rand: () => number,
+  avoid?: Run,
+): Run {
   const { minX, minY, maxX, maxY } = bounds(el);
-  const dir: 1 | -1 = Math.random() < 0.5 ? 1 : -1;
+  const dir: 1 | -1 = rand() < 0.5 ? 1 : -1;
   const flip = avoid && avoid.horizontal === horizontal;
   if (horizontal) {
-    let top = Math.random() < 0.5;
+    let top = rand() < 0.5;
     if (flip && avoid) top = avoid.axis0 !== minY;
     return {
       horizontal,
@@ -84,7 +111,7 @@ function pickRun(el: HTMLElement, horizontal: boolean, avoid?: Run): Run {
       start: dir === 1 ? minX : maxX,
     };
   }
-  let left = Math.random() < 0.5;
+  let left = rand() < 0.5;
   if (flip && avoid) left = avoid.axis0 !== minX;
   return {
     horizontal,
@@ -113,6 +140,12 @@ function travelCells(run: Run) {
 export type FeatureDotFieldProps = {
   /** Extra classes on the absolute-fill wrapper. */
   className?: string;
+  /**
+   * Stable per-card seed (feature index). Desktop + mobile washes on the
+   * same card must share this so one card stays internally consistent.
+   * Derives phase, lead axis, speed, and the rim-run sequence.
+   */
+  seed?: number | string;
 };
 
 /**
@@ -123,7 +156,7 @@ export type FeatureDotFieldProps = {
  * Positioned `absolute inset-0` — drop behind any feature visual. Prefer
  * {@link FeatureStage} when you also need the stacking wrapper.
  */
-export function FeatureDotField({ className }: FeatureDotFieldProps) {
+export function FeatureDotField({ className, seed = 0 }: FeatureDotFieldProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
 
@@ -136,10 +169,22 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
     if (!ctx) return;
 
     const reduced = window.matchMedia("(prefers-reduced-motion: reduce)");
+    // Motion params and rim-run sequence use separate streams so a
+    // layout() re-seed does not replay the phase/speed draws as edges.
+    const motion = mulberry32(hashSeed(seed));
+    const cellsPerSec = CELLS_PER_SEC * (0.86 + motion() * 0.28);
+    const leadHorizontal = motion() < 0.5;
+    const phase0 = motion();
+    const phase1 = motion();
+    const restPhase = motion() * Math.PI * 2;
+    const makeRunRng = () => mulberry32(hashSeed(seed) ^ 0x9e3779b9);
+    let rand = makeRunRng();
+
     type Pulse = { run: Run; started: number };
+    const firstRun = pickRun(root, leadHorizontal, rand);
     const pulses: Pulse[] = [
-      { run: pickRun(root, true), started: 0 },
-      { run: pickRun(root, false), started: 0 },
+      { run: firstRun, started: 0 },
+      { run: pickRun(root, !leadHorizontal, rand, firstRun), started: 0 },
     ];
     let raf = 0;
     let visible = true;
@@ -161,32 +206,30 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
       }
     };
 
+    const durationOf = (run: Run) => (travelCells(run) / cellsPerSec) * 1000;
+
     const headOf = (pulse: Pulse, now: number) => {
       const travel = travelCells(pulse.run);
-      const duration = (travel / CELLS_PER_SEC) * 1000;
-      const e = smoothstep((now - pulse.started) / duration);
+      const e = smoothstep((now - pulse.started) / durationOf(pulse.run));
       return pulse.run.start + pulse.run.dir * e * travel;
     };
 
     const pastEnd = (pulse: Pulse, now: number) => {
-      const travel = travelCells(pulse.run);
-      const duration = (travel / CELLS_PER_SEC) * 1000;
-      return now - pulse.started >= duration;
+      return now - pulse.started >= durationOf(pulse.run);
     };
 
     const paintTravel = (now: number) => {
       const { rect } = bounds(root);
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       if (pulses[0]!.started === 0) {
-        pulses[0]!.started = now;
-        const span = (travelCells(pulses[1]!.run) / CELLS_PER_SEC) * 1000;
-        pulses[1]!.started = now - span * 0.45;
+        pulses[0]!.started = now - durationOf(pulses[0]!.run) * phase0;
+        pulses[1]!.started = now - durationOf(pulses[1]!.run) * phase1;
       }
       for (let n = 0; n < pulses.length; n++) {
         const pulse = pulses[n]!;
         const other = pulses[1 - n]!;
         if (pastEnd(pulse, now)) {
-          pulse.run = pickRun(root, !pulse.run.horizontal, other.run);
+          pulse.run = pickRun(root, !pulse.run.horizontal, rand, other.run);
           pulse.started = now;
         }
         const head = headOf(pulse, now);
@@ -197,7 +240,7 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
     const paintRest = (now: number) => {
       const { rect } = bounds(root);
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      const pulse = 0.28 + 0.28 * (0.5 + 0.5 * Math.sin(now / 900));
+      const pulse = 0.28 + 0.28 * (0.5 + 0.5 * Math.sin(now / 900 + restPhase));
       for (const item of pulses) {
         const mid = ((item.run.from + item.run.to) / 2) | 0;
         for (let depth = 0; depth < EDGE; depth++) {
@@ -221,8 +264,12 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
       canvas.style.width = `${width}px`;
       canvas.style.height = `${height}px`;
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-      pulses[0] = { run: pickRun(root, true), started: 0 };
-      pulses[1] = { run: pickRun(root, false, pulses[0].run), started: 0 };
+      rand = makeRunRng();
+      pulses[0] = { run: pickRun(root, leadHorizontal, rand), started: 0 };
+      pulses[1] = {
+        run: pickRun(root, !leadHorizontal, rand, pulses[0].run),
+        started: 0,
+      };
     };
 
     const tick = (now: number) => {
@@ -251,7 +298,7 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
       ro.disconnect();
       io.disconnect();
     };
-  }, []);
+  }, [seed]);
 
   return (
     <div
@@ -280,6 +327,7 @@ export function FeatureDotField({ className }: FeatureDotFieldProps) {
 
 export type FeatureStageProps = PropsWithChildren<{
   className?: string;
+  seed?: number | string;
 }>;
 
 /**
@@ -287,10 +335,10 @@ export type FeatureStageProps = PropsWithChildren<{
  * Parent must be `position: relative`. Later feature-visual PRs wrap their
  * media in this — do not fork the pulse.
  */
-export function FeatureStage({ children, className }: FeatureStageProps) {
+export function FeatureStage({ children, className, seed }: FeatureStageProps) {
   return (
     <>
-      <FeatureDotField className={className} />
+      <FeatureDotField className={className} seed={seed} />
       <div className="relative z-1 w-full">{children}</div>
     </>
   );

--- a/app/src/components/homepage/features/features.tsx
+++ b/app/src/components/homepage/features/features.tsx
@@ -2,15 +2,17 @@
 
 import Image from "next/image";
 import { type PropsWithChildren, useEffect, useRef } from "react";
+import { cn } from "@/lib/utils";
 import { features } from "./data";
 import { FeatureCard } from "./feature-card";
 
 function FeatureMedia({
   children,
   glow = true,
-}: PropsWithChildren<{ glow?: boolean }>) {
+  className,
+}: PropsWithChildren<{ glow?: boolean; className?: string }>) {
   return (
-    <div className="relative w-full">
+    <div className={cn("relative w-full", className)}>
       {glow ? (
         <div
           className="pointer-events-none absolute left-1/2 top-1/2 -z-10 aspect-5/3 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-full bg-periwinkle-400/25 blur-3xl"
@@ -121,7 +123,12 @@ export function Features({ children }: PropsWithChildren) {
             link={feature.link}
             stage={feature.stage}
           >
-            <FeatureMedia glow={!feature.stage}>
+            <FeatureMedia
+              glow={!feature.stage}
+              className={
+                feature.stage ? "absolute inset-0 size-full" : undefined
+              }
+            >
               {feature.video ? (
                 <video
                   src={feature.video}
@@ -129,7 +136,12 @@ export function Features({ children }: PropsWithChildren) {
                   loop
                   muted
                   title={feature.titleText}
-                  className="relative aspect-auto z-1 w-full rounded-lg object-cover border border-border/50 shadow-lg"
+                  className={cn(
+                    "relative z-1 w-full rounded-lg border border-border/50 shadow-lg",
+                    feature.stage
+                      ? "absolute inset-0 size-full object-contain"
+                      : "aspect-auto object-cover",
+                  )}
                 />
               ) : null}
               {feature.image ? (

--- a/app/src/components/homepage/features/features.tsx
+++ b/app/src/components/homepage/features/features.tsx
@@ -119,9 +119,9 @@ export function Features({ children }: PropsWithChildren) {
             title={feature.title}
             description={feature.description}
             link={feature.link}
-            dotField={feature.titleText === "Agent-ready"}
+            stage={feature.stage}
           >
-            <FeatureMedia glow={feature.titleText !== "Agent-ready"}>
+            <FeatureMedia glow={!feature.stage}>
               {feature.video ? (
                 <video
                   src={feature.video}

--- a/app/src/components/homepage/features/features.tsx
+++ b/app/src/components/homepage/features/features.tsx
@@ -120,7 +120,6 @@ export function Features({ children }: PropsWithChildren) {
             description={feature.description}
             link={feature.link}
             stage={feature.stage}
-            copyPanel={feature.copyPanel}
           >
             <FeatureMedia glow={!feature.stage}>
               {feature.video ? (

--- a/app/src/components/homepage/features/features.tsx
+++ b/app/src/components/homepage/features/features.tsx
@@ -120,6 +120,7 @@ export function Features({ children }: PropsWithChildren) {
             description={feature.description}
             link={feature.link}
             stage={feature.stage}
+            copyPanel={feature.copyPanel}
           >
             <FeatureMedia glow={!feature.stage}>
               {feature.video ? (

--- a/app/src/components/homepage/features/features.tsx
+++ b/app/src/components/homepage/features/features.tsx
@@ -5,13 +5,18 @@ import { type PropsWithChildren, useEffect, useRef } from "react";
 import { features } from "./data";
 import { FeatureCard } from "./feature-card";
 
-function FeatureMedia({ children }: PropsWithChildren) {
+function FeatureMedia({
+  children,
+  glow = true,
+}: PropsWithChildren<{ glow?: boolean }>) {
   return (
     <div className="relative w-full">
-      <div
-        className="pointer-events-none absolute left-1/2 top-1/2 -z-10 aspect-5/3 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-full bg-periwinkle-400/25 blur-3xl"
-        aria-hidden
-      />
+      {glow ? (
+        <div
+          className="pointer-events-none absolute left-1/2 top-1/2 -z-10 aspect-5/3 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-full bg-periwinkle-400/25 blur-3xl"
+          aria-hidden
+        />
+      ) : null}
       {children}
     </div>
   );
@@ -114,8 +119,9 @@ export function Features({ children }: PropsWithChildren) {
             title={feature.title}
             description={feature.description}
             link={feature.link}
+            dotField={feature.titleText === "Agent-ready"}
           >
-            <FeatureMedia>
+            <FeatureMedia glow={feature.titleText !== "Agent-ready"}>
               {feature.video ? (
                 <video
                   src={feature.video}

--- a/app/src/components/homepage/features/modern-interface.tsx
+++ b/app/src/components/homepage/features/modern-interface.tsx
@@ -53,15 +53,15 @@ export function ModernInterface() {
   const [activePreset, setActivePreset] = useState(0);
 
   return (
-    <div className="space-y-4">
-      <div className="grid grid-cols-4 gap-3">
+    <div className="flex size-full min-h-0 flex-col gap-4">
+      <div className="grid shrink-0 grid-cols-4 gap-3">
         {THEME_PRESETS.map((preset, i) => (
           <button
             key={i}
             type="button"
             onClick={() => setActivePreset(i)}
             className={cn(
-              "flex items-center justify-center gap-3 border h-12 rounded-lg",
+              "flex h-12 items-center justify-center gap-3 rounded-lg border",
               activePreset === i && "bg-muted/50",
             )}
           >
@@ -83,11 +83,13 @@ export function ModernInterface() {
           </button>
         ))}
       </div>
-      <div className="border rounded-lg overflow-hidden">
+      <div className="relative min-h-0 flex-1 overflow-hidden rounded-lg border border-border/50 shadow-lg">
         <Image
           src={THEME_PRESETS[activePreset].image}
           alt={THEME_PRESETS[activePreset].label}
-          className="w-full h-full object-cover"
+          fill
+          sizes="(min-width: 1024px) 58vw, 100vw"
+          className="object-cover"
         />
       </div>
     </div>

--- a/app/src/components/homepage/homepage.module.css
+++ b/app/src/components/homepage/homepage.module.css
@@ -78,7 +78,9 @@
       transparent var(--homepage-dot-r)
     );
     background-size: var(--homepage-dot-cell) var(--homepage-dot-cell);
+    background-position: var(--homepage-dot-position, 0 0);
     background-repeat: repeat;
+    background-attachment: var(--homepage-dot-attachment, scroll);
   }
 }
 

--- a/app/src/components/homepage/homepage.module.css
+++ b/app/src/components/homepage/homepage.module.css
@@ -72,7 +72,7 @@
       circle,
       color-mix(
         in srgb,
-        var(--homepage-dot-color, white) 35%,
+        var(--homepage-dot-color, white) var(--homepage-dot-mix, 35%),
         transparent
       ) var(--homepage-dot-r),
       transparent var(--homepage-dot-r)

--- a/app/src/components/homepage/homepage.module.css
+++ b/app/src/components/homepage/homepage.module.css
@@ -84,6 +84,16 @@
   }
 }
 
+/** Soft periwinkle wash — brighter centre, fades to the rim. */
+.homepage-feature-stage-wash {
+  background-image: radial-gradient(
+    ellipse 78% 68% at 50% 46%,
+    color-mix(in srgb, var(--color-periwinkle-500) 18%, transparent) 0%,
+    color-mix(in srgb, var(--color-periwinkle-500) 10%, transparent) 46%,
+    color-mix(in srgb, var(--color-periwinkle-500) 3%, transparent) 100%
+  );
+}
+
 .homepage-spot-glow {
   position: fixed;
   inset: 0;

--- a/app/src/components/homepage/source-files.json
+++ b/app/src/components/homepage/source-files.json
@@ -68,6 +68,7 @@
   "app/src/components/homepage/explore.tsx",
   "app/src/components/homepage/features/data.tsx",
   "app/src/components/homepage/features/feature-card.tsx",
+  "app/src/components/homepage/features/feature-dot-field.tsx",
   "app/src/components/homepage/features/features.tsx",
   "app/src/components/homepage/features/modern-interface.tsx",
   "app/src/components/homepage/footer.tsx",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #556 (`cursor/features-honey-dot-trail-73eb`). Do not merge ahead of that branch.

## Summary

Opts the remaining homepage feature cards into the shared `FeatureDotField` stage already proven on Agent-ready: periwinkle wash + spot grid + dual H/V honey lattice.

Each card’s lattice is seeded from its feature `index`. The stage is locked to the card. Honey travel is 14 cells/sec (σ 4.5). The periwinkle wash is now a **radial fade** — slightly brighter in the centre, softer at the edges — on both desktop and mobile.

This PR does **not** include the top-fold drop-shadow — that stays isolated on #560.

## Scope

- [x] `app/` (hosted site, MCP, Ask AI)
- [ ] `packages/cli/`
- [ ] `packages/mdx-bundler/`
- [ ] `docs/` (product documentation)
- [ ] Repo / CI / other

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan

- [x] `bun run check` passes locally
- [x] Tested locally (`bun dev` on `/`)
- [ ] Updated `docs/` — N/A
- [x] Railway preview

**Preview:** https://docspage-docspage-pr-559.up.railway.app/

**Tip SHA:** `69a40f87308e98cb07ea30c3576bdcf12f9791d2`

## Notes for reviewers

**Wash**

- Before: flat `bg-periwinkle-500/10` (10% everywhere)
- After: shared `homepage-feature-stage-wash` radial — centre 18% → mid 10% → rim 3% (`#5368BD` / `--color-periwinkle-500`)

**Out of scope**

- Does not modify #556 / `cursor/features-honey-dot-trail-73eb`
- Does not include the top-fold shadow (#560)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b8c1debe-31cd-48b0-8052-c8e2f481dfad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b8c1debe-31cd-48b0-8052-c8e2f481dfad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

