### PR TITLE
feat(homepage): top-fold drop shadow on stacked feature cards

### DIFF
--- a/app/src/components/homepage/features/feature-card.tsx
+++ b/app/src/components/homepage/features/feature-card.tsx
@@ -7,6 +7,7 @@ import {
   PAPER_SECTION_OVERLAP_CLASS,
   PAPER_SECTION_SHELL_CLASS,
   PaperCorner,
+  PaperFoldShadow,
   paperCornerClipPath,
 } from "../paper-corner";
 import { FeatureDotField } from "./feature-dot-field";
@@ -78,13 +79,14 @@ export function FeatureCard({
   return (
     <div
       data-stack-card
-      className={cn(PAPER_SECTION_OVERLAP_CLASS, "sticky")}
+      className={cn(PAPER_SECTION_OVERLAP_CLASS, "relative sticky")}
       style={{ top: `${index}rem`, zIndex: index + 1 }}
     >
+      <PaperFoldShadow />
       <div
         className={cn(
           PAPER_SECTION_SHELL_CLASS,
-          "bg-black",
+          "z-10 bg-black",
           stage ? STAGE_STACK_CLEARANCE_CLASS : "pb-20 lg:pb-40",
         )}
         style={{ clipPath: paperCornerClipPath() }}

--- a/app/src/components/homepage/paper-corner.tsx
+++ b/app/src/components/homepage/paper-corner.tsx
@@ -45,14 +45,12 @@ const STROKE_SOLID_PROPS = {
 const PAPER_FROSTED_CLASS = "bg-black/70 backdrop-blur-lg";
 
 /**
- * Soft upward shadow along the paper top-fold + dog-ear.
- * Lives on an unclipped sibling — clip-path on the shell eats box-shadow.
- * Two stacked drop-shadows: a wide lift plus a tighter crease. Tint is
- * black mixed with a whisper of periwinkle so it reads on the dark ground
- * without a heavy all-around haze.
+ * Silhouette bloom of the clipped top fold. Zero-offset blur falls into the
+ * dog-ear cutout (wash-under-fold); the upward pair lifts the straight edge.
+ * Plain rgb() only — color-mix() inside drop-shadow can no-op the filter.
  */
 const PAPER_FOLD_SHADOW_FILTER =
-  "drop-shadow(0 -8px 14px color-mix(in srgb, black 78%, var(--color-periwinkle-500))) drop-shadow(0 -2px 5px rgb(0 0 0 / 0.38))" as const;
+  "drop-shadow(0 0 8px rgb(0 0 0 / 0.55)) drop-shadow(0 -6px 12px rgb(0 0 0 / 0.4))" as const;
 
 type PaperClippedPanelProps = {
   className?: string;
@@ -86,22 +84,40 @@ export function PaperClippedPanel({
 }
 
 /**
- * Casts a lift shadow of the top fold (horizontal edge + diagonal dog-ear)
- * onto the paper underneath. Place as a sibling *behind* the clipped shell.
+ * Layer separation along the paper top-fold. Sibling of the clipped shell
+ * (clip-path eats box-shadow). The silhouette follows the dog-ear; extra
+ * gradients darken the wash in the cutout and the straight edge above.
  */
 export function PaperFoldShadow() {
   return (
     <div
       aria-hidden
-      className="pointer-events-none absolute inset-x-0 top-0 -z-10"
-      style={{
-        height: `${PAPER_FOLD_REM}rem`,
-        filter: PAPER_FOLD_SHADOW_FILTER,
-      }}
+      className="pointer-events-none absolute inset-x-0 top-0 -z-10 overflow-visible"
+      style={{ height: `${PAPER_FOLD_REM}rem` }}
     >
       <div
-        className="size-full bg-black"
-        style={{ clipPath: paperCornerClipPath() }}
+        className="absolute inset-0"
+        style={{ filter: PAPER_FOLD_SHADOW_FILTER }}
+      >
+        <div
+          className="size-full bg-black"
+          style={{ clipPath: paperCornerClipPath() }}
+        />
+      </div>
+      {/* Straight top edge — band sits above the fold onto the card beneath. */}
+      <div
+        className="absolute -top-10 right-0 left-20 h-10"
+        style={{
+          background: "linear-gradient(to top, rgb(0 0 0 / 0.32), transparent)",
+        }}
+      />
+      {/* Dog-ear cutout — darkest at the diagonal, fading into the wash. */}
+      <div
+        className="absolute top-0 left-0 size-20"
+        style={{
+          background:
+            "linear-gradient(to top left, rgb(0 0 0 / 0.38) 10%, transparent 68%)",
+        }}
       />
     </div>
   );

--- a/app/src/components/homepage/paper-corner.tsx
+++ b/app/src/components/homepage/paper-corner.tsx
@@ -44,6 +44,16 @@ const STROKE_SOLID_PROPS = {
 /** Feature cards: black tint + backdrop blur (matches landing-page-new-branding-v2). */
 const PAPER_FROSTED_CLASS = "bg-black/70 backdrop-blur-lg";
 
+/**
+ * Soft upward shadow along the paper top-fold + dog-ear.
+ * Lives on an unclipped sibling — clip-path on the shell eats box-shadow.
+ * Two stacked drop-shadows: a wide lift plus a tighter crease. Tint is
+ * black mixed with a whisper of periwinkle so it reads on the dark ground
+ * without a heavy all-around haze.
+ */
+const PAPER_FOLD_SHADOW_FILTER =
+  "drop-shadow(0 -8px 14px color-mix(in srgb, black 78%, var(--color-periwinkle-500))) drop-shadow(0 -2px 5px rgb(0 0 0 / 0.38))" as const;
+
 type PaperClippedPanelProps = {
   className?: string;
   /** When true (default), applies black frosted surface on the clipped panel. */
@@ -71,6 +81,28 @@ export function PaperClippedPanel({
     >
       <PaperCorner borderGradient={borderGradient} />
       <div className="relative">{children}</div>
+    </div>
+  );
+}
+
+/**
+ * Casts a lift shadow of the top fold (horizontal edge + diagonal dog-ear)
+ * onto the paper underneath. Place as a sibling *behind* the clipped shell.
+ */
+export function PaperFoldShadow() {
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-x-0 top-0 -z-10"
+      style={{
+        height: `${PAPER_FOLD_REM}rem`,
+        filter: PAPER_FOLD_SHADOW_FILTER,
+      }}
+    >
+      <div
+        className="size-full bg-black"
+        style={{ clipPath: paperCornerClipPath() }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Stacked on #559 (`cursor/features-stage-all-cards-dfad`). Do not merge ahead of that branch. Do not land on #556.

## Summary

Adds a soft **upward drop shadow along the top fold** of every homepage feature paper card (Agent-ready through Modern Interface) so stacked/overlapping cards read as separate layers — especially where the stage wash runs under the next dog-ear.

`clip-path` on the paper shell eats `box-shadow`, so the shadow is a sibling of the clipped surface:

- A fold-height slab using the same `paperCornerClipPath()`, with `filter: drop-shadow` (bloom into the cutout + upward lift)
- A short gradient above the straight top edge
- A cutout occlusion along the diagonal

Tint is black only — no all-around haze on the ground.

## Scope

- [x] `app/` (hosted site, MCP, Ask AI)
- [ ] `packages/cli/`
- [ ] `packages/mdx-bundler/`
- [ ] `docs/` (product documentation)
- [ ] Repo / CI / other

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / chore

## Test plan

- [x] `bun run check` passes locally
- [x] Homepage `200` on local `bun dev`
- [ ] Updated `docs/` (if user-facing) — N/A, homepage decoration only
- [ ] Verified on Railway preview

**Preview:** https://docspage-docspage-pr-560.up.railway.app/

**Tip SHA:** `bc611594bf3a5337a4f11e223e06a4a1b6c484df`

## Notes for reviewers

- `PaperFoldShadow` lives next to the other `PAPER_SECTION_*` tokens in `paper-corner.tsx` and is mounted behind the clipped shell in `FeatureCard`.
- PaperCorner, dog-ear SVG, and the wash-under-fold path are unchanged.
- Preview / Explore paper sections are out of scope.
- Strength is a first-pass black lift; tune opacities on preview if it reads too soft or too heavy on the stage wash.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe198fc4-1755-4e68-8079-eb1e9ff59c39?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe198fc4-1755-4e68-8079-eb1e9ff59c39&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

